### PR TITLE
CI revert to main branch

### DIFF
--- a/.github/workflows/generate-chart-readme.yaml
+++ b/.github/workflows/generate-chart-readme.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 permissions: {} # Remove all permissions by default
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   lint-test:
@@ -31,17 +30,11 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.base_ref }} --config ct.yaml)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          ARGS="--target-branch ${{ github.base_ref }} --lint-conf lintconf.yaml --config ct.yaml"
-          # Add an additional argument if the base branch is 'dev'
-          if [ "${{ github.base_ref }}" == "dev" ]; then
-            ARGS="$ARGS --check-version-increment=false"
-          fi
-          ct lint $ARGS
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --lint-conf lintconf.yaml --config ct.yaml

--- a/.github/workflows/push-chart-dev.yaml
+++ b/.github/workflows/push-chart-dev.yaml
@@ -1,63 +1,31 @@
-name: Build & Push Updated Charts (DEV)
+name: Build & Push Updated Charts (MANUAL)
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Name of the branch to checkout (e.g., main, develop)'
+        required: true
+        default: 'main'
+      chart_dir:
+        description: 'Directory of the chart to be pushed (e.g., charts/my-chart)'
+        required: true
+      chart_version:
+        description: 'Version of the chart to be pushed (e.g., 1.2.3). Will be appended with -dev'
+        required: true
 
 jobs:
-  get-modified-charts:
-    runs-on: ubuntu-latest
-    outputs:
-      paths: ${{ steps.get-modified-charts.outputs.paths }}
-    steps:
-      - uses: actions/checkout@master
-        with:
-          fetch-depth: 0
-
-      - name: Get modified charts
-        id: get-modified-charts
-        run: |
-          paths=$(git diff origin/main... --name-only | grep ^charts/ | cut -d/ -f1,2 | uniq | tr '\n' ' ')
-          echo "paths=${paths}" >> $GITHUB_OUTPUT
-
   push-charts:
-    needs: get-modified-charts
     runs-on: ubuntu-latest
-    if: ${{ needs.get-modified-charts.outputs.paths != '' }}
     steps:
-      - uses: actions/checkout@master
-
-      # Create and push git tags
-      - name: Create and push git tags
-        run: |
-          IFS=' ' read -ra ADDR <<< "${{ needs.get-modified-charts.outputs.paths }}"
-          for path in "${ADDR[@]}"; do
-            # Extract the chart name from the path
-            chart_name=$(basename $path)
-            
-            # Only capture the first occurrence of 'version:' to ignore dependencies
-            version=$(grep -m1 'version:' $path/Chart.yaml | awk '{print $2}')
-            
-            # Create the tag name by prepending the chart name and adding '-dev'
-            tag="${chart_name}-${version}-dev"
-
-            # Configure git
-            git config user.name "GitHub Actions"
-            git config user.email "actions@github.com"
-            
-            # Delete existing tag if exists
-            git tag -d $tag || true
-            git push origin :refs/tags/$tag || true
-            
-            # Create and push new tag
-            git tag $tag
-            git push origin $tag
-          done
+      - name: Checkout code
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
 
       - uses: a-thomas-22/helm-push-action@v0.0.28
         env:
-          PATHS: ${{ needs.get-modified-charts.outputs.paths }}
+          PATHS: ${{ github.event.inputs.chart_dir }} 
           FORCE: "True"
           DEV: "True"
           CHARTMUSEUM_URL: "chartmuseum-external.iue1v1-0.i.arbitrum-internal.io/public"


### PR DESCRIPTION
Sets `main` as the main dev branch and makes dev chart push workflow manual.