### PR TITLE
Fix stateless validator topology spread constraints

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.18
+version: 0.1.19
 
 appVersion: "v2.2.3-17468a8"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -156,6 +156,9 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `validator.statefulset.livenessProbe.tcpSocket.port`       | Port to probe                                            | `auth`               |
 | `validator.statefulset.livenessProbe.initialDelaySeconds`  | Initial delay for the liveness probe                     | `30`                 |
 | `validator.statefulset.livenessProbe.periodSeconds`        | Period for the liveness probe                            | `10`                 |
+| `validator.statefulset.pdb.enabled`                        | Enable pod disruption budget                             | `false`              |
+| `validator.statefulset.pdb.minAvailable`                   | Minimum number of pods available                         | `75%`                |
+| `validator.statefulset.pdb.maxUnavailable`                 | Maximum number of pods unavailable                       | `""`                 |
 | `validator.statefulset.readinessProbe.enabled`             | Enable the readiness probe for the validator statefulset | `true`               |
 | `validator.statefulset.readinessProbe.tcpSocket.port`      | Port to probe                                            | `auth`               |
 | `validator.statefulset.readinessProbe.initialDelaySeconds` | Initial delay for the readiness probe                    | `3`                  |

--- a/charts/nitro/templates/pdb.yaml
+++ b/charts/nitro/templates/pdb.yaml
@@ -15,4 +15,5 @@ spec:
   selector:
     matchLabels:
       {{- include "nitro.selectorLabels" . | nindent 6 }}
+      function: nitro
 {{- end }}

--- a/charts/nitro/templates/service.yaml
+++ b/charts/nitro/templates/service.yaml
@@ -48,3 +48,4 @@ spec:
     {{- end }}
   selector:
     {{- include "nitro.selectorLabels" . | nindent 4 }}
+    function: nitro

--- a/charts/nitro/templates/statefulset.yaml
+++ b/charts/nitro/templates/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
         {{- end }}
       labels:
         {{- include "nitro.selectorLabels" . | nindent 8 }}
+        function: nitro
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -198,6 +199,7 @@ spec:
         labelSelector:
           matchLabels:
             {{- include "nitro.selectorLabels" $ | nindent 12 }}
+            function: nitro
         {{- end }}
         {{- end }}
       {{- end }}

--- a/charts/nitro/templates/validator/pdb.yaml
+++ b/charts/nitro/templates/validator/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.validator.statefulset.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nitro.fullname" . }}
+  labels:
+    {{- include "nitro.labels" . | nindent 4 }}
+spec:
+  {{- if and (.Values.validator.statefulset.pdb.minAvailable) (not .Values.validator.statefulset.pdb.maxUnavailable) }}
+  minAvailable: {{ .Values.validator.statefulset.pdb.minAvailable }}
+  {{- end }}
+  {{- if and (.Values.validator.statefulset.pdb.maxUnavailable) (not .Values.validator.statefulset.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.validator.statefulset.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "nitro.selectorLabels" . | nindent 6 }}
+      function: arb-validator
+{{- end }}

--- a/charts/nitro/templates/validator/pdb.yaml
+++ b/charts/nitro/templates/validator/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.validator.statefulset.enabled }}
+{{- if .Values.validator.statefulset.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -228,6 +228,14 @@ validator:
       initialDelaySeconds: 30
       periodSeconds: 10
 
+    ## @param validator.statefulset.pdb.enabled Enable pod disruption budget
+    ## @param validator.statefulset.pdb.minAvailable Minimum number of pods available
+    ## @param validator.statefulset.pdb.maxUnavailable Maximum number of pods unavailable
+    pdb:
+      enabled: false
+      minAvailable: "75%"
+      maxUnavailable: ""
+
     ## @param validator.statefulset.readinessProbe.enabled Enable the readiness probe for the validator statefulset
     ## @param validator.statefulset.readinessProbe.tcpSocket.port Port to probe
     ## @param validator.statefulset.readinessProbe.initialDelaySeconds Initial delay for the readiness probe


### PR DESCRIPTION
This fixes a few issues:

- Service not properly selecting the right pods since it wasn't granular enough with selectors
- Topology spread constraints and pdbs not properly selecting the appropriate sts