### PR TITLE
Add chain label to Nitro metrics

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.10
+version: 0.1.11
 
 appVersion: "v2.2.3-17468a8"

--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.11
+version: 0.1.12
 
 appVersion: "v2.2.4-8517340"

--- a/charts/das/README.md
+++ b/charts/das/README.md
@@ -156,7 +156,6 @@ extraEnv:
 
 | Name                                            | Description                                                                 | Value                       |
 | ----------------------------------------------- | --------------------------------------------------------------------------- | --------------------------- |
-| `chain.name`                                    | Name of the chain                                                           | `CHANGEME`                  |
 | `replicaCount`                                  | Number of replicas                                                          | `1`                         |
 | `image.repository`                              | Docker image repository                                                     | `offchainlabs/nitro-node`   |
 | `image.pullPolicy`                              | Docker image pull policy                                                    | `Always`                    |
@@ -181,6 +180,7 @@ extraEnv:
 | `serviceMonitor.portName`                       | Name of the port to monitor                                                 | `metrics`                   |
 | `serviceMonitor.path`                           | Path to monitor                                                             | `/debug/metrics/prometheus` |
 | `serviceMonitor.interval`                       | Interval to monitor                                                         | `5s`                        |
+| `serviceMonitor.relabelings`                    | Add relabelings for the metrics being scraped                               | `{}`                        |
 | `perReplicaService.enabled`                     | Enable per replica service                                                  | `false`                     |
 | `headlessservice.enabled`                       | Enable headless service                                                     | `false`                     |
 | `pdb.enabled`                                   | Enable pod disruption budget                                                | `false`                     |

--- a/charts/das/README.md
+++ b/charts/das/README.md
@@ -156,6 +156,7 @@ extraEnv:
 
 | Name                                            | Description                                                                 | Value                       |
 | ----------------------------------------------- | --------------------------------------------------------------------------- | --------------------------- |
+| `chain.name`                                    | Name of the chain                                                           | `CHANGEME`                  |
 | `replicaCount`                                  | Number of replicas                                                          | `1`                         |
 | `image.repository`                              | Docker image repository                                                     | `offchainlabs/nitro-node`   |
 | `image.pullPolicy`                              | Docker image pull policy                                                    | `Always`                    |

--- a/charts/das/templates/servicemonitor.yaml
+++ b/charts/das/templates/servicemonitor.yaml
@@ -27,10 +27,9 @@ spec:
       tlsConfig: 
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
-      relabelings:
-        - targetLabel: chain
-          replacement: {{ .Values.chain.name }}
-          action: replace
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/das/templates/servicemonitor.yaml
+++ b/charts/das/templates/servicemonitor.yaml
@@ -27,6 +27,9 @@ spec:
       tlsConfig: 
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
+      relabelings:
+        - target_label: chain
+          replacement: {{ .Values.chain.name }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/das/templates/servicemonitor.yaml
+++ b/charts/das/templates/servicemonitor.yaml
@@ -28,8 +28,9 @@ spec:
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
       relabelings:
-        - target_label: chain
+        - targetLabel: chain
           replacement: {{ .Values.chain.name }}
+          action: replace
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/das/values.yaml
+++ b/charts/das/values.yaml
@@ -1,9 +1,5 @@
 ## @section DAS Deployment Options
 
-## @param chain.name Name of the chain
-chain:
-  name: CHANGEME
-
 ## @param replicaCount Number of replicas
 replicaCount: 1
 
@@ -63,11 +59,13 @@ persistence:
 ## @param serviceMonitor.portName Name of the port to monitor
 ## @param serviceMonitor.path Path to monitor
 ## @param serviceMonitor.interval Interval to monitor
+## @param serviceMonitor.relabelings Add relabelings for the metrics being scraped
 serviceMonitor:
   enabled: false
   portName: metrics
   path: /debug/metrics/prometheus
   interval: 5s
+  relabelings: {}
 
 ## @param perReplicaService.enabled Enable per replica service
 perReplicaService:

--- a/charts/das/values.yaml
+++ b/charts/das/values.yaml
@@ -1,5 +1,9 @@
 ## @section DAS Deployment Options
 
+## @param chain.name Name of the chain
+chain:
+  name: CHANGEME
+
 ## @param replicaCount Number of replicas
 replicaCount: 1
 

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.18
+version: 0.1.19
 
 appVersion: "v2.2.3-17468a8"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.19
+version: 0.1.20
 
 appVersion: "v2.2.4-8517340"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -170,6 +170,7 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `validator.statefulset.extraEnv`                           | Extra environment variables for the validator container  | `{}`                 |
 | `validator.statefulset.extraPorts`                         | Additional ports for the stateless validator pod         | `[]`                 |
 | `validator.statefulset.metrics.enabled`                    | Enable metrics for the validator statefulset             | `false`              |
+| `validator.statefulset.metrics.relabelings`                | Add relabelings for the metrics being scraped            | `{}`                 |
 | `validator.statefulset.podAnnotations`                     | Annotations for the stateless validator pod              | `{}`                 |
 
 ## Configuration Options

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -73,7 +73,6 @@ helm install xai offchainlabs/nitro -f values.yaml
 
 | Name                                         | Description                                                  | Value                                                       |
 | -------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
-| `chain.name`                                 | Name of the chain                                            | `CHANGEME`                                                  |
 | `replicaCount`                               | Number of replicas to deploy                                 | `1`                                                         |
 | `image.repository`                           | Docker image repository                                      | `offchainlabs/nitro-node`                                   |
 | `image.pullPolicy`                           | Docker image pull policy                                     | `Always`                                                    |
@@ -96,6 +95,7 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `serviceMonitor.portName`                    | Name of the port to monitor                                  | `metrics`                                                   |
 | `serviceMonitor.path`                        | Path to monitor                                              | `/debug/metrics/prometheus`                                 |
 | `serviceMonitor.interval`                    | Interval to monitor                                          | `5s`                                                        |
+| `serviceMonitor.relabelings`                 | Add relabelings for the metrics being scraped                | `{}`                                                        |
 | `perReplicaService.enabled`                  | Enable a service for each sts replica                        | `false`                                                     |
 | `jwtSecret.enabled`                          | Enable a jwt secret for use with the stateless validator     | `false`                                                     |
 | `jwtSecret.value`                            | Value of the jwt secret for use with the stateless validator | `""`                                                        |
@@ -126,6 +126,7 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `configmap.data.http.vhosts`                 | Vhosts to allow                                              | `*`                                                         |
 | `configmap.data.parent-chain.id`             | ID of the parent chain                                       | `1`                                                         |
 | `configmap.data.parent-chain.connection.url` | URL of the parent chain                                      | `""`                                                        |
+| `configmap.data.chain.name`                  | Name of the chain                                            | `""`                                                        |
 | `configmap.data.chain.id`                    | ID of the chain                                              | `42161`                                                     |
 | `configmap.data.log-type`                    | Type of log                                                  | `json`                                                      |
 | `configmap.data.metrics`                     | Enable metrics                                               | `false`                                                     |

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -126,7 +126,6 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `configmap.data.http.vhosts`                 | Vhosts to allow                                              | `*`                                                         |
 | `configmap.data.parent-chain.id`             | ID of the parent chain                                       | `1`                                                         |
 | `configmap.data.parent-chain.connection.url` | URL of the parent chain                                      | `""`                                                        |
-| `configmap.data.chain.name`                  | Name of the chain                                            | `""`                                                        |
 | `configmap.data.chain.id`                    | ID of the chain                                              | `42161`                                                     |
 | `configmap.data.log-type`                    | Type of log                                                  | `json`                                                      |
 | `configmap.data.metrics`                     | Enable metrics                                               | `false`                                                     |

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -73,6 +73,7 @@ helm install xai offchainlabs/nitro -f values.yaml
 
 | Name                                         | Description                                                  | Value                                                       |
 | -------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
+| `chain.name`                                 | Name of the chain                                            | `CHANGEME`                                                  |
 | `replicaCount`                               | Number of replicas to deploy                                 | `1`                                                         |
 | `image.repository`                           | Docker image repository                                      | `offchainlabs/nitro-node`                                   |
 | `image.pullPolicy`                           | Docker image pull policy                                     | `Always`                                                    |

--- a/charts/nitro/templates/servicemonitor.yaml
+++ b/charts/nitro/templates/servicemonitor.yaml
@@ -27,10 +27,9 @@ spec:
       tlsConfig: 
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
-      relabelings:
-        - targetLabel: chain
-          replacement: {{ .Values.chain.name }}
-          action: replace
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/nitro/templates/servicemonitor.yaml
+++ b/charts/nitro/templates/servicemonitor.yaml
@@ -27,6 +27,9 @@ spec:
       tlsConfig: 
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
+      relabelings:
+        - target_label: chain
+          replacement: {{ .Values.chain.name }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/nitro/templates/servicemonitor.yaml
+++ b/charts/nitro/templates/servicemonitor.yaml
@@ -28,8 +28,9 @@ spec:
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
       relabelings:
-        - target_label: chain
+        - targetLabel: chain
           replacement: {{ .Values.chain.name }}
+          action: replace
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/nitro/templates/validator/servicemonitor.yaml
+++ b/charts/nitro/templates/validator/servicemonitor.yaml
@@ -19,6 +19,9 @@ spec:
     interval: 5s
     path: /debug/metrics
     scheme: http
+    {{- with .Values.validator.statefulset.metrics.relabelings }}
+    relabelings: {{- toYaml . | nindent 4 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -1,5 +1,9 @@
 ## @section Nitro Deployment Options
 
+## @param chain.name Name of the chain
+chain:
+  name: CHANGEME
+
 ## @param replicaCount Number of replicas to deploy
 ##
 replicaCount: 1

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -1,9 +1,5 @@
 ## @section Nitro Deployment Options
 
-## @param chain.name Name of the chain
-chain:
-  name: CHANGEME
-
 ## @param replicaCount Number of replicas to deploy
 ##
 replicaCount: 1
@@ -60,11 +56,13 @@ persistence:
 ## @param serviceMonitor.portName Name of the port to monitor
 ## @param serviceMonitor.path Path to monitor
 ## @param serviceMonitor.interval Interval to monitor
+## @param serviceMonitor.relabelings Add relabelings for the metrics being scraped
 serviceMonitor:
   enabled: false
   portName: metrics
   path: /debug/metrics/prometheus
   interval: 5s
+  relabelings: {}
 
 ## @param perReplicaService.enabled Enable a service for each sts replica
 perReplicaService:
@@ -154,8 +152,10 @@ configmap:
       connection:
         url: ""
 
+    ## @param configmap.data.chain.name Name of the chain
     ## @param configmap.data.chain.id ID of the chain
     chain:
+      name: ""
       id: 42161
 
     ## @param configmap.data.log-type Type of log

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -152,10 +152,8 @@ configmap:
       connection:
         url: ""
 
-    ## @param configmap.data.chain.name Name of the chain
     ## @param configmap.data.chain.id ID of the chain
     chain:
-      name: ""
       id: 42161
 
     ## @param configmap.data.log-type Type of log

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -265,8 +265,10 @@ validator:
     extraPorts: []
 
     ## @param validator.statefulset.metrics.enabled Enable metrics for the validator statefulset
+    ## @param validator.statefulset.metrics.relabelings Add relabelings for the metrics being scraped
     metrics:
       enabled: false
+      relabelings: {}
 
     ## @param validator.statefulset.podAnnotations Annotations for the stateless validator pod
     podAnnotations: {}

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.12
+version: 0.1.13
 
 appVersion: "v2.2.3-17468a8"

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.13
+version: 0.1.14
 
 appVersion: "v2.2.4-8517340"

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -36,7 +36,6 @@ helm install <my-release> offchainlabs/relay \
 
 | Name                                              | Description                                      | Value                       |
 | ------------------------------------------------- | ------------------------------------------------ | --------------------------- |
-| `chain.name`                                      | Name of the chain                                | `CHANGEME`                  |
 | `replicaCount`                                    | Number of replicas to deploy                     | `1`                         |
 | `image.repository`                                | Docker image repository                          | `offchainlabs/nitro-node`   |
 | `image.pullPolicy`                                | Docker image pull policy                         | `Always`                    |
@@ -70,6 +69,7 @@ helm install <my-release> offchainlabs/relay \
 | `serviceMonitor.portName`                         | Port name for prometheus service monitor         | `metrics`                   |
 | `serviceMonitor.path`                             | Path for prometheus service monitor              | `/debug/metrics/prometheus` |
 | `serviceMonitor.interval`                         | Interval for prometheus service monitor          | `5s`                        |
+| `serviceMonitor.relabelings`                      | Add relabelings for the metrics being scraped    | `{}`                        |
 | `perReplicaService.enabled`                       | Enable per replica service                       | `false`                     |
 | `pdb.enabled`                                     | Enable pod disruption budget                     | `false`                     |
 | `pdb.minAvailable`                                | Minimum number of available pods                 | `75%`                       |

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -36,6 +36,7 @@ helm install <my-release> offchainlabs/relay \
 
 | Name                                              | Description                                      | Value                       |
 | ------------------------------------------------- | ------------------------------------------------ | --------------------------- |
+| `chain.name`                                      | Name of the chain                                | `CHANGEME`                  |
 | `replicaCount`                                    | Number of replicas to deploy                     | `1`                         |
 | `image.repository`                                | Docker image repository                          | `offchainlabs/nitro-node`   |
 | `image.pullPolicy`                                | Docker image pull policy                         | `Always`                    |

--- a/charts/relay/templates/servicemonitor.yaml
+++ b/charts/relay/templates/servicemonitor.yaml
@@ -27,10 +27,9 @@ spec:
       tlsConfig: 
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
-      relabelings:
-        - targetLabel: chain
-          replacement: {{ .Values.chain.name }}
-          action: replace
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/relay/templates/servicemonitor.yaml
+++ b/charts/relay/templates/servicemonitor.yaml
@@ -27,6 +27,9 @@ spec:
       tlsConfig: 
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
+      relabelings:
+        - target_label: chain
+          replacement: {{ .Values.chain.name }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/relay/templates/servicemonitor.yaml
+++ b/charts/relay/templates/servicemonitor.yaml
@@ -28,8 +28,9 @@ spec:
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
       relabelings:
-        - target_label: chain
+        - targetLabel: chain
           replacement: {{ .Values.chain.name }}
+          action: replace
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/relay/values.yaml
+++ b/charts/relay/values.yaml
@@ -1,5 +1,9 @@
 ## @section Relay
 
+## @param chain.name Name of the chain
+chain:
+  name: CHANGEME
+
 ## @param replicaCount Number of replicas to deploy
 replicaCount: 1
 

--- a/charts/relay/values.yaml
+++ b/charts/relay/values.yaml
@@ -1,9 +1,5 @@
 ## @section Relay
 
-## @param chain.name Name of the chain
-chain:
-  name: CHANGEME
-
 ## @param replicaCount Number of replicas to deploy
 replicaCount: 1
 
@@ -83,11 +79,13 @@ startupProbe:
 ## @param serviceMonitor.portName Port name for prometheus service monitor
 ## @param serviceMonitor.path Path for prometheus service monitor
 ## @param serviceMonitor.interval Interval for prometheus service monitor
+## @param serviceMonitor.relabelings Add relabelings for the metrics being scraped
 serviceMonitor:
   enabled: false
   portName: metrics
   path: /debug/metrics/prometheus
   interval: 5s
+  relabelings: {}
 
 ## @param perReplicaService.enabled Enable per replica service
 perReplicaService:


### PR DESCRIPTION
[ticket](https://www.notion.so/arbitrum/Blockscout-alerts-9dfadf0f3f13438993adb425bbfca721?pvs=4)

Adding a chain label to the Nitro, Relay and LB service monitors. This will enable us to compare metrics within a chain against each other.