### PR TITLE
Add stateless validator monitoring support

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.21
+version: 0.2.0
 
 appVersion: "v2.2.4-8517340"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -148,6 +148,9 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `validator.configmap.data.auth.port`                       | Port to bind auth service to                             | `8549`                      |
 | `validator.configmap.data.auth.origins`                    | Origins to allow to access auth service                  | `*`                         |
 | `validator.configmap.data.auth.jwtsecret`                  | Path to jwt secret for auth service                      | `/secrets/jwtsecret`        |
+| `validator.configmap.data.metrics`                         | Enable metrics                                           | `false`                     |
+| `validator.configmap.data.metrics-server.addr`             | Address to bind metrics server to                        | `0.0.0.0`                   |
+| `validator.configmap.data.metrics-server.port`             | Port to bind metrics server to                           | `6070`                      |
 | `validator.extraArgs`                                      | Extra arguments for the validator container              | `[]`                        |
 | `validator.serviceMonitor.enabled`                         | Enable service monitor CRD for prometheus operator       | `false`                     |
 | `validator.serviceMonitor.portName`                        | Name of the port to monitor                              | `metrics`                   |

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -139,38 +139,41 @@ helm install xai offchainlabs/nitro -f values.yaml
 
 ### Stateless Validator
 
-| Name                                                       | Description                                              | Value                |
-| ---------------------------------------------------------- | -------------------------------------------------------- | -------------------- |
-| `validator.image.repository`                               | Docker image repository                                  | `""`                 |
-| `validator.image.tag`                                      | Docker image tag                                         | `""`                 |
-| `validator.enabled`                                        | Enable the stateless validator                           | `false`              |
-| `validator.configmap.data.auth.addr`                       | Address to bind auth service to                          | `0.0.0.0`            |
-| `validator.configmap.data.auth.port`                       | Port to bind auth service to                             | `8549`               |
-| `validator.configmap.data.auth.origins`                    | Origins to allow to access auth service                  | `*`                  |
-| `validator.configmap.data.auth.jwtsecret`                  | Path to jwt secret for auth service                      | `/secrets/jwtsecret` |
-| `validator.extraArgs`                                      | Extra arguments for the validator container              | `[]`                 |
-| `validator.statefulset.useConfigmap`                       | Use the configmap for the validator container            | `true`               |
-| `validator.statefulset.auth.enabled`                       | Enable the auth service for the validator statefulset    | `true`               |
-| `validator.statefulset.auth.port`                          | Port to bind auth service to                             | `8549`               |
-| `validator.statefulset.extraLabels`                        | Extra labels for the liveness probe                      | `{}`                 |
-| `validator.statefulset.livenessProbe.enabled`              | Enable the liveness probe for the validator statefulset  | `true`               |
-| `validator.statefulset.livenessProbe.tcpSocket.port`       | Port to probe                                            | `auth`               |
-| `validator.statefulset.livenessProbe.initialDelaySeconds`  | Initial delay for the liveness probe                     | `30`                 |
-| `validator.statefulset.livenessProbe.periodSeconds`        | Period for the liveness probe                            | `10`                 |
-| `validator.statefulset.pdb.enabled`                        | Enable pod disruption budget                             | `false`              |
-| `validator.statefulset.pdb.minAvailable`                   | Minimum number of pods available                         | `75%`                |
-| `validator.statefulset.pdb.maxUnavailable`                 | Maximum number of pods unavailable                       | `""`                 |
-| `validator.statefulset.readinessProbe.enabled`             | Enable the readiness probe for the validator statefulset | `true`               |
-| `validator.statefulset.readinessProbe.tcpSocket.port`      | Port to probe                                            | `auth`               |
-| `validator.statefulset.readinessProbe.initialDelaySeconds` | Initial delay for the readiness probe                    | `3`                  |
-| `validator.statefulset.readinessProbe.periodSeconds`       | Period for the readiness probe                           | `3`                  |
-| `validator.statefulset.startupProbe.enabled`               | Enable the startup probe for the validator statefulset   | `false`              |
-| `validator.statefulset.resources`                          | Resources for the validator container                    | `{}`                 |
-| `validator.statefulset.extraEnv`                           | Extra environment variables for the validator container  | `{}`                 |
-| `validator.statefulset.extraPorts`                         | Additional ports for the stateless validator pod         | `[]`                 |
-| `validator.statefulset.metrics.enabled`                    | Enable metrics for the validator statefulset             | `false`              |
-| `validator.statefulset.metrics.relabelings`                | Add relabelings for the metrics being scraped            | `{}`                 |
-| `validator.statefulset.podAnnotations`                     | Annotations for the stateless validator pod              | `{}`                 |
+| Name                                                       | Description                                              | Value                       |
+| ---------------------------------------------------------- | -------------------------------------------------------- | --------------------------- |
+| `validator.image.repository`                               | Docker image repository                                  | `""`                        |
+| `validator.image.tag`                                      | Docker image tag                                         | `""`                        |
+| `validator.enabled`                                        | Enable the stateless validator                           | `false`                     |
+| `validator.configmap.data.auth.addr`                       | Address to bind auth service to                          | `0.0.0.0`                   |
+| `validator.configmap.data.auth.port`                       | Port to bind auth service to                             | `8549`                      |
+| `validator.configmap.data.auth.origins`                    | Origins to allow to access auth service                  | `*`                         |
+| `validator.configmap.data.auth.jwtsecret`                  | Path to jwt secret for auth service                      | `/secrets/jwtsecret`        |
+| `validator.extraArgs`                                      | Extra arguments for the validator container              | `[]`                        |
+| `validator.serviceMonitor.enabled`                         | Enable service monitor CRD for prometheus operator       | `false`                     |
+| `validator.serviceMonitor.portName`                        | Name of the port to monitor                              | `metrics`                   |
+| `validator.serviceMonitor.path`                            | Path to monitor                                          | `/debug/metrics/prometheus` |
+| `validator.serviceMonitor.interval`                        | Interval to monitor                                      | `5s`                        |
+| `validator.serviceMonitor.relabelings`                     | Add relabelings for the metrics being scraped            | `{}`                        |
+| `validator.statefulset.useConfigmap`                       | Use the configmap for the validator container            | `true`                      |
+| `validator.statefulset.auth.enabled`                       | Enable the auth service for the validator statefulset    | `true`                      |
+| `validator.statefulset.auth.port`                          | Port to bind auth service to                             | `8549`                      |
+| `validator.statefulset.extraLabels`                        | Extra labels for the liveness probe                      | `{}`                        |
+| `validator.statefulset.livenessProbe.enabled`              | Enable the liveness probe for the validator statefulset  | `true`                      |
+| `validator.statefulset.livenessProbe.tcpSocket.port`       | Port to probe                                            | `auth`                      |
+| `validator.statefulset.livenessProbe.initialDelaySeconds`  | Initial delay for the liveness probe                     | `30`                        |
+| `validator.statefulset.livenessProbe.periodSeconds`        | Period for the liveness probe                            | `10`                        |
+| `validator.statefulset.pdb.enabled`                        | Enable pod disruption budget                             | `false`                     |
+| `validator.statefulset.pdb.minAvailable`                   | Minimum number of pods available                         | `75%`                       |
+| `validator.statefulset.pdb.maxUnavailable`                 | Maximum number of pods unavailable                       | `""`                        |
+| `validator.statefulset.readinessProbe.enabled`             | Enable the readiness probe for the validator statefulset | `true`                      |
+| `validator.statefulset.readinessProbe.tcpSocket.port`      | Port to probe                                            | `auth`                      |
+| `validator.statefulset.readinessProbe.initialDelaySeconds` | Initial delay for the readiness probe                    | `3`                         |
+| `validator.statefulset.readinessProbe.periodSeconds`       | Period for the readiness probe                           | `3`                         |
+| `validator.statefulset.startupProbe.enabled`               | Enable the startup probe for the validator statefulset   | `false`                     |
+| `validator.statefulset.resources`                          | Resources for the validator container                    | `{}`                        |
+| `validator.statefulset.extraEnv`                           | Extra environment variables for the validator container  | `{}`                        |
+| `validator.statefulset.extraPorts`                         | Additional ports for the stateless validator pod         | `[]`                        |
+| `validator.statefulset.podAnnotations`                     | Annotations for the stateless validator pod              | `{}`                        |
 
 ## Configuration Options
 The following table lists the exhaustive configurable parameters that can be applied as part of the configmap (nested under `configmap.data`) or as standalone cli flags.

--- a/charts/nitro/templates/validator/service.yaml
+++ b/charts/nitro/templates/validator/service.yaml
@@ -18,9 +18,9 @@ spec:
       protocol: TCP
       name: auth
   {{- end }}
-  {{- if $.Values.validator.statefulset.metrics.enabled }}
-    - port: {{ $.Values.validator.statefulset.metrics.port }}
-      targetPort: {{ $.Values.validator.statefulset.metrics.port }}
+  {{- if .Values.validator.configmap.data.metrics }}
+    - port: {{ index .Values "validator" "configmap" "data" "metrics-server" "port" }}
+      targetPort: metrics
       protocol: TCP
       name: metrics
   {{- end }}

--- a/charts/nitro/templates/validator/servicemonitor.yaml
+++ b/charts/nitro/templates/validator/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and $.Values.validator.enabled $.Values.validator.statefulset.serviceMonitor.enabled }}
+{{- if and $.Values.validator.enabled $.Values.validator.serviceMonitor.enabled }}
 {{- $fullName := include "nitro.fullname" . }}
 {{- $labels := include "nitro.labels" . }}
 {{- $selectorLabels := include "nitro.selectorLabels" .}}

--- a/charts/nitro/templates/validator/servicemonitor.yaml
+++ b/charts/nitro/templates/validator/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and $.Values.validator.enabled $.Values.validator.statefulset.metrics.enabled }}
+{{- if and $.Values.validator.enabled $.Values.validator.statefulset.serviceMonitor.enabled }}
 {{- $fullName := include "nitro.fullname" . }}
 {{- $labels := include "nitro.labels" . }}
 {{- $selectorLabels := include "nitro.selectorLabels" .}}
@@ -15,13 +15,26 @@ spec:
       {{- $selectorLabels | nindent 6 }}
       function: arb-validator
   endpoints:
-  - port: metrics
-    interval: 5s
-    path: /debug/metrics
-    scheme: http
-    {{- with .Values.validator.statefulset.metrics.relabelings }}
-    relabelings: {{- toYaml . | nindent 4 }}
-    {{- end }}
+    - port: {{ .Values.validator.serviceMonitor.portName | default "http" }}
+      {{- if .Values.validator.serviceMonitor.interval }}
+      interval: {{ .Values.validator.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.validator.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.validator.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.validator.serviceMonitor.path }}
+      path: {{ .Values.validator.serviceMonitor.path }}
+      {{- end }}
+      {{- if .Values.validator.serviceMonitor.scheme }}
+      scheme: {{ .Values.validator.serviceMonitor.scheme }}
+      {{- end }}
+      {{- if .Values.validator.serviceMonitor.tlsConfig }}
+      tlsConfig: 
+        {{- toYaml .Values.validator.serviceMonitor.tlsConfig | nindent 8 }}
+      {{- end }}
+      {{- with .Values.validator.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/nitro/templates/validator/statefulset.yaml
+++ b/charts/nitro/templates/validator/statefulset.yaml
@@ -71,7 +71,9 @@ spec:
         image: "{{ .Values.validator.image.repository | default .Values.image.repository }}:{{ .Values.validator.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
         command: ["/usr/local/bin/nitro-val"]
         args:
-          - --conf.env-prefix=NITRO
+          {{- if .Values.validator.configmap.data.metrics}}
+          - --metrics
+          {{- end }}
           {{- if .Values.validator.statefulset.useConfigmap }}
           - --conf.file=/config/config.json
           {{- end }}
@@ -84,6 +86,16 @@ spec:
         {{- if .Values.validator.statefulset.auth.enabled }}
         - name: auth
           containerPort: {{ .Values.validator.statefulset.auth.port }}
+        {{- end }}
+        {{- if .Values.validator.configmap.data.metrics }}
+        - name: metrics
+          containerPort: {{ index .Values "validator" "configmap" "data" "metrics-server" "port" }}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.validator.configmap.data.pprof }}
+        - name: pprof
+          containerPort: {{ index .Values "validator" "configmap" "data" "pprof-cfg" "port" }}
+          protocol: TCP
         {{- end }}
         {{- range .Values.validator.statefulset.extraPorts }}
         - name: {{ .name }}

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -203,6 +203,14 @@ validator:
         origins: "*"
         jwtsecret: "/secrets/jwtsecret"
 
+      ## @param validator.configmap.data.metrics Enable metrics
+      ## @param validator.configmap.data.metrics-server.addr Address to bind metrics server to
+      ## @param validator.configmap.data.metrics-server.port Port to bind metrics server to
+      metrics: false
+      metrics-server:
+        addr: "0.0.0.0"
+        port: 6070
+
   ## @param validator.extraArgs Extra arguments for the validator container
   extraArgs: []
 

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -262,10 +262,16 @@ validator:
     ## @param validator.statefulset.extraPorts Additional ports for the stateless validator pod
     extraPorts: []
 
-    ## @param validator.statefulset.metrics.enabled Enable metrics for the validator statefulset
-    ## @param validator.statefulset.metrics.relabelings Add relabelings for the metrics being scraped
-    metrics:
+    ## @param validator.serviceMonitor.enabled Enable service monitor CRD for prometheus operator
+    ## @param validator.serviceMonitor.portName Name of the port to monitor
+    ## @param validator.serviceMonitor.path Path to monitor
+    ## @param validator.serviceMonitor.interval Interval to monitor
+    ## @param validator.serviceMonitor.relabelings Add relabelings for the metrics being scraped
+    serviceMonitor:
       enabled: false
+      portName: metrics
+      path: /debug/metrics/prometheus
+      interval: 5s
       relabelings: {}
 
     ## @param validator.statefulset.podAnnotations Annotations for the stateless validator pod

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -206,6 +206,18 @@ validator:
   ## @param validator.extraArgs Extra arguments for the validator container
   extraArgs: []
 
+  ## @param validator.serviceMonitor.enabled Enable service monitor CRD for prometheus operator
+  ## @param validator.serviceMonitor.portName Name of the port to monitor
+  ## @param validator.serviceMonitor.path Path to monitor
+  ## @param validator.serviceMonitor.interval Interval to monitor
+  ## @param validator.serviceMonitor.relabelings Add relabelings for the metrics being scraped
+  serviceMonitor:
+    enabled: false
+    portName: metrics
+    path: /debug/metrics/prometheus
+    interval: 5s
+    relabelings: {}
+
   statefulset:
     ## @param validator.statefulset.useConfigmap Use the configmap for the validator container
     useConfigmap: true
@@ -261,18 +273,6 @@ validator:
 
     ## @param validator.statefulset.extraPorts Additional ports for the stateless validator pod
     extraPorts: []
-
-    ## @param validator.serviceMonitor.enabled Enable service monitor CRD for prometheus operator
-    ## @param validator.serviceMonitor.portName Name of the port to monitor
-    ## @param validator.serviceMonitor.path Path to monitor
-    ## @param validator.serviceMonitor.interval Interval to monitor
-    ## @param validator.serviceMonitor.relabelings Add relabelings for the metrics being scraped
-    serviceMonitor:
-      enabled: false
-      portName: metrics
-      path: /debug/metrics/prometheus
-      interval: 5s
-      relabelings: {}
 
     ## @param validator.statefulset.podAnnotations Annotations for the stateless validator pod
     podAnnotations: {}


### PR DESCRIPTION
This fixes the servicemonitor and makes it more inline with the regular nitro config options