### PR TITLE
Change stateless validator container name

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 appVersion: "v2.2.4-8517340"

--- a/charts/nitro/templates/validator/statefulset.yaml
+++ b/charts/nitro/templates/validator/statefulset.yaml
@@ -67,7 +67,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
-      - name: validator
+      - name: {{ .Chart.Name }}-stateless
         image: "{{ .Values.validator.image.repository | default .Values.image.repository }}:{{ .Values.validator.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
         command: ["/usr/local/bin/nitro-val"]
         args:


### PR DESCRIPTION
Makes the container name predictable and line up with the parent sts.

In practice we can use this for alerting to separate out stateless validators since they have undesirable metrics like not connecting to a feed and not having a block-height.