### PR TITLE
Unescape Escaped html characters in `toPrettyJson`

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.13
+version: 0.1.14
 
 appVersion: "v2.2.4-8517340"

--- a/charts/das/templates/configmap.yaml
+++ b/charts/das/templates/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   config.json: |
     {{- if .Values.configmap.enabled }}
-    {{- .Values.configmap.data | toPrettyJson | nindent 4 }}
+    {{- .Values.configmap.data | toRawJson | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/das/templates/configmap.yaml
+++ b/charts/das/templates/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   config.json: |
     {{- if .Values.configmap.enabled }}
-    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
+    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | replace "\\u003c" "<" | replace "\\u003e" ">" | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/das/templates/configmap.yaml
+++ b/charts/das/templates/configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   config.json: |
     {{- if .Values.configmap.enabled }}
-    {{- .Values.configmap.data | toRawJson | nindent 4 }}
+    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 appVersion: "v2.2.4-8517340"

--- a/charts/nitro/templates/configmap.yaml
+++ b/charts/nitro/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "nitro.labels" . | nindent 4 }}
 data:
   config.json: |
-    {{- .Values.configmap.data | toPrettyJson | nindent 4 }}
+    {{- .Values.configmap.data | toRawJson | nindent 4 }}
 {{- end }}

--- a/charts/nitro/templates/configmap.yaml
+++ b/charts/nitro/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "nitro.labels" . | nindent 4 }}
 data:
   config.json: |
-    {{- .Values.configmap.data | toRawJson | nindent 4 }}
+    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
 {{- end }}

--- a/charts/nitro/templates/configmap.yaml
+++ b/charts/nitro/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "nitro.labels" . | nindent 4 }}
 data:
   config.json: |
-    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
+    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | replace "\\u003c" "<" | replace "\\u003e" ">" | nindent 4 }}
 {{- end }}

--- a/charts/nitro/templates/validator/configmap.yaml
+++ b/charts/nitro/templates/validator/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   config.json: |
   {{- if  and .Values.validator.configmap  .Values.validator.configmap.data }}
-    {{- .Values.validator.configmap.data | toRawJson | nindent 4 }}
+    {{- .Values.validator.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
   {{- end }} 
   
 {{- end }}

--- a/charts/nitro/templates/validator/configmap.yaml
+++ b/charts/nitro/templates/validator/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   config.json: |
   {{- if  and .Values.validator.configmap  .Values.validator.configmap.data }}
-    {{- .Values.validator.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
+    {{- .Values.validator.configmap.data | toPrettyJson | replace "\\u0026" "&" | replace "\\u003c" "<" | replace "\\u003e" ">" | nindent 4 }}
   {{- end }} 
   
 {{- end }}

--- a/charts/nitro/templates/validator/configmap.yaml
+++ b/charts/nitro/templates/validator/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   config.json: |
   {{- if  and .Values.validator.configmap  .Values.validator.configmap.data }}
-    {{- .Values.validator.configmap.data | toPrettyJson | nindent 4 }}
+    {{- .Values.validator.configmap.data | toRawJson | nindent 4 }}
   {{- end }} 
   
 {{- end }}

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.15
+version: 0.1.16
 
 appVersion: "v2.2.4-8517340"

--- a/charts/relay/templates/configmap.yaml
+++ b/charts/relay/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "relay.labels" . | nindent 4 }}
 data:
   config.json: |
-    {{- .Values.configmap.data | toPrettyJson | nindent 4 }}
+    {{- .Values.configmap.data | toRawJson | nindent 4 }}
 {{- end }}

--- a/charts/relay/templates/configmap.yaml
+++ b/charts/relay/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "relay.labels" . | nindent 4 }}
 data:
   config.json: |
-    {{- .Values.configmap.data | toRawJson | nindent 4 }}
+    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
 {{- end }}

--- a/charts/relay/templates/configmap.yaml
+++ b/charts/relay/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "relay.labels" . | nindent 4 }}
 data:
   config.json: |
-    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | nindent 4 }}
+    {{- .Values.configmap.data | toPrettyJson | replace "\\u0026" "&" | replace "\\u003c" "<" | replace "\\u003e" ">" | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
`toPrettyJson` escapes html characters. This is problematic for things like the parent url where many providers have `&` in their uri.

https://github.com/helm/helm/issues/8872

The best option for full support of special characters is to use `toRawJson` instead of `toPrettyJson`, however that makes diffs impossible to read.

Since the substitution set is small, I think manually replacing affected characters is the best solution. 

helm uses go sprig templating which uses encoding/json to do this.

Here is the code:

https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/encoding/json/indent.go;l=9

So these replacements should catch all cases where we don't want this behavior.