### PR TITLE
Add test hook to ci configmap

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.2.5
+version: 0.2.6
 
 appVersion: "v2.2.5-a20a1c7"

--- a/charts/nitro/templates/tests/test.yaml
+++ b/charts/nitro/templates/tests/test.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ include "nitro.fullname" . }}-ci-configmap"
+  annotations:
+    "helm.sh/hook": test
 data:
   config.yaml: |
     {{- $ciValues := omit .Values.ci "secrets" }}


### PR DESCRIPTION
Without this annotation it is always installed, even when not running tests