### PR TITLE
[SRE-772] Upgrade to v2.3.0-3e14543

### DIFF
--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -40,6 +40,7 @@ jobs:
           CI_TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.CI_TEST_ACCOUNT_PRIVATE_KEY }}
           CI_PARENT_CHAIN_URL_SEPOLIA: ${{ secrets.CI_PARENT_CHAIN_URL_SEPOLIA }}
           CI_BASELINE_RPC_KEY_SEPOLIA: ${{ secrets.CI_BASELINE_RPC_KEY_SEPOLIA }}
+          CI_PARENT_CHAIN_BLOB_CLIENT_URL: ${{ secrets.CI_PARENT_CHAIN_BLOB_CLIENT_URL }}
           # Map additional secrets as needed
         run: |
           secrets_for_helm=""

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -40,6 +40,7 @@ jobs:
           CI_TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.CI_TEST_ACCOUNT_PRIVATE_KEY }}
           CI_PARENT_CHAIN_URL_SEPOLIA: ${{ secrets.CI_PARENT_CHAIN_URL_SEPOLIA }}
           CI_BASELINE_RPC_KEY_SEPOLIA: ${{ secrets.CI_BASELINE_RPC_KEY_SEPOLIA }}
+          CI_PARENT_CHAIN_BLOB_CLIENT_URL: ${{ secrets.CI_PARENT_CHAIN_BLOB_CLIENT_URL }}
           # Map additional secrets as needed
         run: |
           secrets_for_helm=""

--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.18
+version: 0.2.0
 
-appVersion: "v2.2.5-a20a1c7"
+appVersion: "v2.3.0-3e14543"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.2.6
+version: 0.3.0
 
-appVersion: "v2.2.5-a20a1c7"
+appVersion: "v2.3.0-3e14543"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -382,8 +382,6 @@ Option | Description | Default
 `node.batch-poster.redis-url` | string                                                              if non-empty, the Redis URL to store queued transactions in | None
 `node.batch-poster.use-access-lists` | post batches with access lists to reduce gas usage (disabled for L3s) | `true`
 `node.batch-poster.wait-for-max-delay` | wait for the max batch delay, even if the batch is full | None
-`node.blob-client.beacon-chain-url` | string                                                        Beacon Chain url to use for fetching blobs | None
-`node.blob-client.blob-directory` | string                                                          Full path of the directory to save fetched blobs | None
 `node.block-validator.current-module-root` | string                                                 current wasm module root ('current' read from chain, 'latest' from machines/latest dir, or provide hash) | `current`
 `node.block-validator.dangerous.reset-block-validation` | resets block-by-block validation, starting again at genesis | None
 `node.block-validator.enable` | enable block-by-block validation | None
@@ -402,6 +400,7 @@ Option | Description | Default
 `node.block-validator.validation-server.retry-errors` | string                                      Errors matching this regular expression are automatically retried | `websocket: close.*|dial tcp .*|.*i/o timeout|.*connection reset by peer|.*connection refused`
 `node.block-validator.validation-server.timeout` | duration                                         per-response timeout (0-disabled) | None
 `node.block-validator.validation-server.url` | string                                               url of server, use self for loopback websocket, self-auth for loopback with authentication | `self-auth`
+`node.dangerous.disable-blob-reader` | DANGEROUS! disables the EIP-4844 blob reader, which is necessary to read batches | None
 `node.dangerous.no-l1-listener` | DANGEROUS! disables listening to L1. To be used in test nodes only | None
 `node.dangerous.no-sequencer-coordinator` | DANGEROUS! allows sequencing without sequencer-coordinator | None
 `node.data-availability.enable` | enable Anytrust Data Availability mode | None
@@ -593,6 +592,8 @@ Option | Description | Default
 `p2p.max-peers` | int                                                                               P2P max peers | `50`
 `p2p.no-dial` | P2P no dial | `true`
 `p2p.no-discovery` | P2P no discovery | `true`
+`parent-chain.blob-client.beacon-url` | string                                                      Beacon Chain RPC URL to use for fetching blobs (normally on port 3500) | None
+`parent-chain.blob-client.blob-directory` | string                                                  Full path of the directory to save fetched blobs | None
 `parent-chain.connection.arg-log-limit` | uint                                                      limit size of arguments in log entries | `2048`
 `parent-chain.connection.connection-wait` | duration                                                how long to wait for initial connection | `1m0s`
 `parent-chain.connection.jwtsecret` | string                                                        path to file with jwtsecret for validation - ignored if url is self or self-auth | None

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -91,6 +91,9 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `persistence.enabled`                        | Enable persistence                                           | `true`                                                      |
 | `persistence.size`                           | Size of the persistent volume claim                          | `500Gi`                                                     |
 | `persistence.storageClassName`               | Storage class of the persistent volume claim                 | `nil`                                                       |
+| `blobPersistence.enabled`                    | Enable blob persistence                                      | `false`                                                     |
+| `blobPersistence.size`                       | Size of the blob persistent volume claim                     | `100Gi`                                                     |
+| `blobPersistence.storageClassName`           | Storage class of the blob persistent volume claim            | `nil`                                                       |
 | `serviceMonitor.enabled`                     | Enable service monitor CRD for prometheus operator           | `false`                                                     |
 | `serviceMonitor.portName`                    | Name of the port to monitor                                  | `metrics`                                                   |
 | `serviceMonitor.path`                        | Path to monitor                                              | `/debug/metrics/prometheus`                                 |

--- a/charts/nitro/ci/sepolia-values.yaml
+++ b/charts/nitro/ci/sepolia-values.yaml
@@ -10,6 +10,9 @@ readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 3
 
+blobPersistence:
+  enabled: true
+
 configmap:
   data:
     conf:
@@ -18,6 +21,8 @@ configmap:
       id: 421614
     parent-chain:
       id: 11155111
+      blob-client:
+        blob-directory: /home/user/blobdata/
 
 extraEnv:
   - name: NITROCI_PARENT__CHAIN_CONNECTION_URL

--- a/charts/nitro/ci/sepolia-values.yaml
+++ b/charts/nitro/ci/sepolia-values.yaml
@@ -25,6 +25,11 @@ extraEnv:
       secretKeyRef:
         name: ci-secret-nitro
         key: PARENT_CHAIN_URL_SEPOLIA
+  - name: NITROCI_PARENT__CHAIN_BLOB__CLIENT_BEACON__URL
+    valueFrom:
+      secretKeyRef:
+        name: ci-secret-nitro
+        key: PARENT_CHAIN_BLOB_CLIENT_URL
 
 ci:
   nitro-secret:

--- a/charts/nitro/templates/statefulset.yaml
+++ b/charts/nitro/templates/statefulset.yaml
@@ -141,9 +141,13 @@ spec:
             mountPath: /secrets/jwtsecret
             subPath: jwtSecret
             readOnly: true
-        {{- end }}
+          {{- end }}
           - name: nitrodata
             mountPath: {{ .Values.configmap.data.persistent.chain }}
+          {{- end }}
+          {{- if .Values.blobPersistence.enabled }}
+          - name: nitroblobdata
+            mountPath: {{ index .Values "configmap" "data" "parent-chain" "blob-client" "blob-directory" }}
           {{- end }}
           {{- if .Values.configmap.enabled }}
           - name: config
@@ -227,4 +231,25 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
+      {{- end }}
+      {{- if .Values.blobPersistence.enabled }}
+    - metadata:
+        name: nitroblobdata
+        {{- with .Values.storageAnnotations }}
+        annotations:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        labels:
+          app: {{ template "nitro.name" . }}
+          release: {{ .Release.Name }}
+          heritage: {{ .Release.Service }}
+      spec: 
+        accessModes:
+        - "ReadWriteOnce"
+        {{- if .Values.blobPersistence.storageClassName }}
+        storageClassName: {{ .Values.blobPersistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.blobPersistence.size | quote }}
       {{- end }}

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -52,6 +52,14 @@ persistence:
   size: 500Gi
   storageClassName: null
 
+## @param blobPersistence.enabled Enable blob persistence
+## @param blobPersistence.size Size of the blob persistent volume claim
+## @param blobPersistence.storageClassName [string, nullable] Storage class of the blob persistent volume claim
+blobPersistence:
+  enabled: false
+  size: 100Gi
+  storageClassName: null
+
 ## @param serviceMonitor.enabled Enable service monitor CRD for prometheus operator
 ## @param serviceMonitor.portName Name of the port to monitor
 ## @param serviceMonitor.path Path to monitor

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.1.18
+version: 0.2.0
 
-appVersion: "v2.2.5-a20a1c7"
+appVersion: "v2.3.0-3e14543"


### PR DESCRIPTION
This version requires blob api access. Chart modifications allow an additional volume to be associated with the sts for blob storage. Alternatively a path could be specified on the existing pvc.

To support development, this PR also includes CI changes to allow access to a consensus endpoint.