### PR TITLE
Update default security context settings

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 appVersion: "v2.3.2-064fa11"

--- a/charts/das/README.md
+++ b/charts/das/README.md
@@ -202,7 +202,11 @@ extraEnv:
 | `serviceAccount.annotations`                    | Annotations for the service account                                         | `{}`                        |
 | `serviceAccount.name`                           | Name of the service account                                                 | `""`                        |
 | `podAnnotations`                                | Annotations for the das pod                                                 | `{}`                        |
-| `podSecurityContext`                            | Security context for the das pod                                            | `{}`                        |
+| `podSecurityContext.fsGroup`                    | Group id for the pod                                                        | `1000`                      |
+| `podSecurityContext.runAsGroup`                 | Group id for the user                                                       | `1000`                      |
+| `podSecurityContext.runAsNonRoot`               | Run as non root                                                             | `true`                      |
+| `podSecurityContext.runAsUser`                  | User id for the user                                                        | `1000`                      |
+| `podSecurityContext.fsGroupChangePolicy`        | Policy for the fs group                                                     | `OnRootMismatch`            |
 | `securityContext`                               | Security context for the das container                                      | `{}`                        |
 | `service.type`                                  | Service type                                                                | `ClusterIP`                 |
 | `resources`                                     | Resource requests and limits for the das container                          | `{}`                        |

--- a/charts/das/templates/statefulset.yaml
+++ b/charts/das/templates/statefulset.yaml
@@ -30,7 +30,6 @@ spec:
         {{- with .Values.podSecurityContext }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-        fsGroup: 1000
       initContainers:
       {{- if .Values.initContainers }}
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/charts/das/values.yaml
+++ b/charts/das/values.yaml
@@ -115,8 +115,17 @@ serviceAccount:
 ## @param podAnnotations Annotations for the das pod
 podAnnotations: {}
 
-## @param podSecurityContext Security context for the das pod
-podSecurityContext: {}
+## @param podSecurityContext.fsGroup Group id for the pod
+## @param podSecurityContext.runAsGroup Group id for the user
+## @param podSecurityContext.runAsNonRoot Run as non root
+## @param podSecurityContext.runAsUser User id for the user
+## @param podSecurityContext.fsGroupChangePolicy Policy for the fs group
+podSecurityContext:
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
 
 ## @param securityContext Security context for the das container
 securityContext: {}

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.3.23
+version: 0.3.24
 
 appVersion: "v2.3.2-064fa11"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -113,6 +113,10 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `serviceAccount.name`                        | Name of the service account                                  | `""`                                                        |
 | `podAnnotations`                             | Annotations for the pod                                      | `{}`                                                        |
 | `podSecurityContext.fsGroup`                 | Group id for the pod                                         | `1000`                                                      |
+| `podSecurityContext.runAsGroup`              | Group id for the user                                        | `1000`                                                      |
+| `podSecurityContext.runAsNonRoot`            | Run as non root                                              | `true`                                                      |
+| `podSecurityContext.runAsUser`               | User id for the user                                         | `1000`                                                      |
+| `podSecurityContext.fsGroupChangePolicy`     | Policy for the fs group                                      | `OnRootMismatch`                                            |
 | `securityContext`                            | Security context for the container                           | `{}`                                                        |
 | `service.type`                               | Service type                                                 | `ClusterIP`                                                 |
 | `resources`                                  | Resources for the container                                  | `{}`                                                        |

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -106,8 +106,16 @@ serviceAccount:
 podAnnotations: {}
 
 ## @param podSecurityContext.fsGroup Group id for the pod
+## @param podSecurityContext.runAsGroup Group id for the user
+## @param podSecurityContext.runAsNonRoot Run as non root
+## @param podSecurityContext.runAsUser User id for the user
+## @param podSecurityContext.fsGroupChangePolicy Policy for the fs group
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
 
 ## @param securityContext Security context for the container
 securityContext: {}

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 appVersion: "v2.3.2-064fa11"

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -78,7 +78,11 @@ helm install <my-release> offchainlabs/relay \
 | `serviceAccount.annotations`                      | Annotations for the service account              | `{}`                        |
 | `serviceAccount.name`                             | Name of the service account                      | `""`                        |
 | `podAnnotations`                                  | Annotations for the pod                          | `{}`                        |
-| `podSecurityContext`                              | Security context for the pod                     | `{}`                        |
+| `podSecurityContext.fsGroup`                      | Group id for the pod                             | `1000`                      |
+| `podSecurityContext.runAsGroup`                   | Group id for the user                            | `1000`                      |
+| `podSecurityContext.runAsNonRoot`                 | Run as non root                                  | `true`                      |
+| `podSecurityContext.runAsUser`                    | User id for the user                             | `1000`                      |
+| `podSecurityContext.fsGroupChangePolicy`          | Policy for the fs group                          | `OnRootMismatch`            |
 | `securityContext`                                 | Security context for the container               | `{}`                        |
 | `service.type`                                    | Service type                                     | `ClusterIP`                 |
 | `resources`                                       | Resources for the container                      | `{}`                        |

--- a/charts/relay/templates/deployment.yaml
+++ b/charts/relay/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
         {{- with .Values.podSecurityContext }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-        fsGroup: 1000
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/relay/values.yaml
+++ b/charts/relay/values.yaml
@@ -110,8 +110,17 @@ serviceAccount:
 ## @param podAnnotations Annotations for the pod
 podAnnotations: {}
 
-## @param podSecurityContext Security context for the pod
-podSecurityContext: {}
+## @param podSecurityContext.fsGroup Group id for the pod
+## @param podSecurityContext.runAsGroup Group id for the user
+## @param podSecurityContext.runAsNonRoot Run as non root
+## @param podSecurityContext.runAsUser User id for the user
+## @param podSecurityContext.fsGroupChangePolicy Policy for the fs group
+podSecurityContext:
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
 
 ## @param securityContext Security context for the container
 securityContext: {}


### PR DESCRIPTION
Specifically this is to fix long mount times with large volumes described here:

https://blog.devgenius.io/when-k8s-pods-are-stuck-mounting-large-volumes-2915e6656cb8

Additionally this standardizes the security context settings to match best practices.