### PR TITLE
update das chart rest-aggregator params

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
 appVersion: "v2.3.3-6a1c1a7"

--- a/charts/das/README.md
+++ b/charts/das/README.md
@@ -226,42 +226,46 @@ extraEnv:
 
 ### DAS Config options
 
-| Name                                                                      | Description                                                                              | Value     |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------- |
-| `configmap.enabled`                                                       | Enable configmap                                                                         | `true`    |
-| `configmap.data`                                                          | Data for the configmap. See Configuration Options for the full list of available options |           |
-| `configmap.data.conf.env-prefix`                                          | Environment variable prefix                                                              | `NITRO`   |
-| `configmap.data.log-type`                                                 | Log type                                                                                 | `json`    |
-| `configmap.data.log-level`                                                | Log level                                                                                | `3`       |
-| `configmap.data.enable-rest`                                              | Enable rest api                                                                          | `true`    |
-| `configmap.data.rest-addr`                                                | Rest api address                                                                         | `0.0.0.0` |
-| `configmap.data.rest-port`                                                | Rest api port                                                                            | `9877`    |
-| `configmap.data.enable-rpc`                                               | Enable rpc api                                                                           | `false`   |
-| `configmap.data.rpc-addr`                                                 | rpc api address                                                                          | `0.0.0.0` |
-| `configmap.data.rpc-port`                                                 | rpc api port                                                                             | `9876`    |
-| `configmap.data.data-availability.parent-chain-node-url`                  | Parent chain node url                                                                    | `""`      |
-| `configmap.data.data-availability.sequencer-inbox-address`                | Sequencer inbox address                                                                  | `""`      |
-| `configmap.data.data-availability.local-db-storage.enable`                | Enable local db storage                                                                  | `false`   |
-| `configmap.data.data-availability.local-db-storage.data-dir`              | Data directory                                                                           | `""`      |
-| `configmap.data.data-availability.local-db-storage.discard-after-timeout` | Discard after timeout                                                                    | `""`      |
-| `configmap.data.data-availability.local-file-storage.enable`              | Enable local file storage                                                                | `false`   |
-| `configmap.data.data-availability.local-file-storage.data-dir`            |                                                                                          | `""`      |
-| `configmap.data.data-availability.s3-storage.enable`                      | Enable s3 storage                                                                        | `false`   |
-| `configmap.data.data-availability.s3-storage.access-key`                  | s3 access key                                                                            | `""`      |
-| `configmap.data.data-availability.s3-storage.bucket`                      | s3 bucket                                                                                | `""`      |
-| `configmap.data.data-availability.s3-storage.discard-after-timeout`       | discard after timeout                                                                    | `""`      |
-| `configmap.data.data-availability.s3-storage.object-prefix`               | object prefix                                                                            | `""`      |
-| `configmap.data.data-availability.s3-storage.region`                      | region                                                                                   | `""`      |
-| `configmap.data.data-availability.s3-storage.secret-key`                  | s3 secret key                                                                            | `""`      |
-| `configmap.data.data-availability.ipfs-storage.enable`                    | Enable ipfs storage                                                                      | `false`   |
-| `configmap.data.data-availability.ipfs-storage.profiles`                  | ipfs profiles                                                                            | `""`      |
-| `configmap.data.data-availability.ipfs-storage.read-timeout`              | ipfs read timeout                                                                        | `1m0s`    |
-| `configmap.data.data-availability.local-cache.enable`                     | Enable local cache                                                                       | `false`   |
-| `configmap.data.data-availability.local-cache.capacity`                   | Maximum number of entries (up to 64KB each) to store in the cache.                       | `20000`   |
-| `configmap.data.metrics`                                                  | Enable metrics                                                                           | `false`   |
-| `configmap.data.metrics-server.addr`                                      | Metrics server address                                                                   | `0.0.0.0` |
-| `configmap.data.metrics-server.port`                                      | Metrics server port                                                                      | `6070`    |
-| `configmap.data.metrics-server.update-interval`                           | Metrics server update interval                                                           | `5s`      |
+| Name                                                                                       | Description                                                                              | Value     |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | --------- |
+| `configmap.enabled`                                                                        | Enable configmap                                                                         | `true`    |
+| `configmap.data`                                                                           | Data for the configmap. See Configuration Options for the full list of available options |           |
+| `configmap.data.conf.env-prefix`                                                           | Environment variable prefix                                                              | `NITRO`   |
+| `configmap.data.log-type`                                                                  | Log type                                                                                 | `json`    |
+| `configmap.data.log-level`                                                                 | Log level                                                                                | `3`       |
+| `configmap.data.enable-rest`                                                               | Enable rest api                                                                          | `true`    |
+| `configmap.data.rest-addr`                                                                 | Rest api address                                                                         | `0.0.0.0` |
+| `configmap.data.rest-port`                                                                 | Rest api port                                                                            | `9877`    |
+| `configmap.data.enable-rpc`                                                                | Enable rpc api                                                                           | `false`   |
+| `configmap.data.rpc-addr`                                                                  | rpc api address                                                                          | `0.0.0.0` |
+| `configmap.data.rpc-port`                                                                  | rpc api port                                                                             | `9876`    |
+| `configmap.data.data-availability.parent-chain-node-url`                                   | Parent chain node url                                                                    | `""`      |
+| `configmap.data.data-availability.sequencer-inbox-address`                                 | Sequencer inbox address                                                                  | `""`      |
+| `configmap.data.data-availability.local-db-storage.enable`                                 | Enable local db storage                                                                  | `false`   |
+| `configmap.data.data-availability.local-db-storage.data-dir`                               | Data directory                                                                           | `""`      |
+| `configmap.data.data-availability.local-db-storage.discard-after-timeout`                  | Discard after timeout                                                                    | `""`      |
+| `configmap.data.data-availability.local-file-storage.enable`                               | Enable local file storage                                                                | `false`   |
+| `configmap.data.data-availability.local-file-storage.data-dir`                             |                                                                                          | `""`      |
+| `configmap.data.data-availability.s3-storage.enable`                                       | Enable s3 storage                                                                        | `false`   |
+| `configmap.data.data-availability.s3-storage.access-key`                                   | s3 access key                                                                            | `""`      |
+| `configmap.data.data-availability.s3-storage.bucket`                                       | s3 bucket                                                                                | `""`      |
+| `configmap.data.data-availability.s3-storage.discard-after-timeout`                        | discard after timeout                                                                    | `""`      |
+| `configmap.data.data-availability.s3-storage.object-prefix`                                | object prefix                                                                            | `""`      |
+| `configmap.data.data-availability.s3-storage.region`                                       | region                                                                                   | `""`      |
+| `configmap.data.data-availability.s3-storage.secret-key`                                   | s3 secret key                                                                            | `""`      |
+| `configmap.data.data-availability.ipfs-storage.enable`                                     | Enable ipfs storage                                                                      | `false`   |
+| `configmap.data.data-availability.ipfs-storage.profiles`                                   | ipfs profiles                                                                            | `""`      |
+| `configmap.data.data-availability.ipfs-storage.read-timeout`                               | ipfs read timeout                                                                        | `1m0s`    |
+| `configmap.data.data-availability.local-cache.enable`                                      | Enable local cache                                                                       | `false`   |
+| `configmap.data.data-availability.local-cache.capacity`                                    | Maximum number of entries (up to 64KB each) to store in the cache.                       | `20000`   |
+| `configmap.data.data-availability.rest-aggregator.enable`                                  | Enable rest aggregator                                                                   | `false`   |
+| `configmap.data.data-availability.rest-aggregator.sync-to-storage.eager`                   | Enable eagerly syncing batch data to this DAS's storage                                  | `false`   |
+| `configmap.data.data-availability.rest-aggregator.sync-to-storage.state-dir`               | Sync to storage directory                                                                | `""`      |
+| `configmap.data.data-availability.rest-aggregator.sync-to-storage.eager-lower-bound-block` | Start indexing forward from this L1 block                                                | `""`      |
+| `configmap.data.metrics`                                                                   | Enable metrics                                                                           | `false`   |
+| `configmap.data.metrics-server.addr`                                                       | Metrics server address                                                                   | `0.0.0.0` |
+| `configmap.data.metrics-server.port`                                                       | Metrics server port                                                                      | `6070`    |
+| `configmap.data.metrics-server.update-interval`                                            | Metrics server update interval                                                           | `5s`      |
 
 ## Configuration Options
 The following table lists the exhaustive configurable parameters that can be applied as part of the configmap (nested under `configmap.data`) or as standalone cli flags.

--- a/charts/das/README.md
+++ b/charts/das/README.md
@@ -226,45 +226,42 @@ extraEnv:
 
 ### DAS Config options
 
-| Name                                                                                       | Description                                                                              | Value     |
-| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | --------- |
-| `configmap.enabled`                                                                        | Enable configmap                                                                         | `true`    |
-| `configmap.data`                                                                           | Data for the configmap. See Configuration Options for the full list of available options |           |
-| `configmap.data.conf.env-prefix`                                                           | Environment variable prefix                                                              | `NITRO`   |
-| `configmap.data.log-type`                                                                  | Log type                                                                                 | `json`    |
-| `configmap.data.log-level`                                                                 | Log level                                                                                | `3`       |
-| `configmap.data.enable-rest`                                                               | Enable rest api                                                                          | `true`    |
-| `configmap.data.rest-addr`                                                                 | Rest api address                                                                         | `0.0.0.0` |
-| `configmap.data.rest-port`                                                                 | Rest api port                                                                            | `9877`    |
-| `configmap.data.enable-rpc`                                                                | Enable rpc api                                                                           | `false`   |
-| `configmap.data.rpc-addr`                                                                  | rpc api address                                                                          | `0.0.0.0` |
-| `configmap.data.rpc-port`                                                                  | rpc api port                                                                             | `9876`    |
-| `configmap.data.data-availability.parent-chain-node-url`                                   | Parent chain node url                                                                    | `""`      |
-| `configmap.data.data-availability.sequencer-inbox-address`                                 | Sequencer inbox address                                                                  | `""`      |
-| `configmap.data.data-availability.local-db-storage.enable`                                 | Enable local db storage                                                                  | `false`   |
-| `configmap.data.data-availability.local-db-storage.data-dir`                               | Data directory                                                                           | `""`      |
-| `configmap.data.data-availability.local-db-storage.discard-after-timeout`                  | Discard after timeout                                                                    | `""`      |
-| `configmap.data.data-availability.local-file-storage.enable`                               | Enable local file storage                                                                | `false`   |
-| `configmap.data.data-availability.local-file-storage.data-dir`                             |                                                                                          | `""`      |
-| `configmap.data.data-availability.s3-storage.enable`                                       | Enable s3 storage                                                                        | `false`   |
-| `configmap.data.data-availability.s3-storage.access-key`                                   | s3 access key                                                                            | `""`      |
-| `configmap.data.data-availability.s3-storage.bucket`                                       | s3 bucket                                                                                | `""`      |
-| `configmap.data.data-availability.s3-storage.discard-after-timeout`                        | discard after timeout                                                                    | `""`      |
-| `configmap.data.data-availability.s3-storage.object-prefix`                                | object prefix                                                                            | `""`      |
-| `configmap.data.data-availability.s3-storage.region`                                       | region                                                                                   | `""`      |
-| `configmap.data.data-availability.s3-storage.secret-key`                                   | s3 secret key                                                                            | `""`      |
-| `configmap.data.data-availability.ipfs-storage.enable`                                     | Enable ipfs storage                                                                      | `false`   |
-| `configmap.data.data-availability.ipfs-storage.profiles`                                   | ipfs profiles                                                                            | `""`      |
-| `configmap.data.data-availability.ipfs-storage.read-timeout`                               | ipfs read timeout                                                                        | `1m0s`    |
-| `configmap.data.data-availability.local-cache.enable`                                      | Enable local cache                                                                       | `false`   |
-| `configmap.data.data-availability.local-cache.capacity`                                    | Maximum number of entries (up to 64KB each) to store in the cache.                       | `20000`   |
-| `configmap.data.data-availability.rest-aggregator.sync-to-storage.eager`                   | Enable eagerly syncing batch data to this DAS's storage                                  | `false`   |
-| `configmap.data.data-availability.rest-aggregator.sync-to-storage.state-dir`               | Sync to storage directory                                                                | `""`      |
-| `configmap.data.data-availability.rest-aggregator.sync-to-storage.eager-lower-bound-block` | Start indexing forward from this L1 block                                                | `""`      |
-| `configmap.data.metrics`                                                                   | Enable metrics                                                                           | `false`   |
-| `configmap.data.metrics-server.addr`                                                       | Metrics server address                                                                   | `0.0.0.0` |
-| `configmap.data.metrics-server.port`                                                       | Metrics server port                                                                      | `6070`    |
-| `configmap.data.metrics-server.update-interval`                                            | Metrics server update interval                                                           | `5s`      |
+| Name                                                                      | Description                                                                              | Value     |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------- |
+| `configmap.enabled`                                                       | Enable configmap                                                                         | `true`    |
+| `configmap.data`                                                          | Data for the configmap. See Configuration Options for the full list of available options |           |
+| `configmap.data.conf.env-prefix`                                          | Environment variable prefix                                                              | `NITRO`   |
+| `configmap.data.log-type`                                                 | Log type                                                                                 | `json`    |
+| `configmap.data.log-level`                                                | Log level                                                                                | `3`       |
+| `configmap.data.enable-rest`                                              | Enable rest api                                                                          | `true`    |
+| `configmap.data.rest-addr`                                                | Rest api address                                                                         | `0.0.0.0` |
+| `configmap.data.rest-port`                                                | Rest api port                                                                            | `9877`    |
+| `configmap.data.enable-rpc`                                               | Enable rpc api                                                                           | `false`   |
+| `configmap.data.rpc-addr`                                                 | rpc api address                                                                          | `0.0.0.0` |
+| `configmap.data.rpc-port`                                                 | rpc api port                                                                             | `9876`    |
+| `configmap.data.data-availability.parent-chain-node-url`                  | Parent chain node url                                                                    | `""`      |
+| `configmap.data.data-availability.sequencer-inbox-address`                | Sequencer inbox address                                                                  | `""`      |
+| `configmap.data.data-availability.local-db-storage.enable`                | Enable local db storage                                                                  | `false`   |
+| `configmap.data.data-availability.local-db-storage.data-dir`              | Data directory                                                                           | `""`      |
+| `configmap.data.data-availability.local-db-storage.discard-after-timeout` | Discard after timeout                                                                    | `""`      |
+| `configmap.data.data-availability.local-file-storage.enable`              | Enable local file storage                                                                | `false`   |
+| `configmap.data.data-availability.local-file-storage.data-dir`            |                                                                                          | `""`      |
+| `configmap.data.data-availability.s3-storage.enable`                      | Enable s3 storage                                                                        | `false`   |
+| `configmap.data.data-availability.s3-storage.access-key`                  | s3 access key                                                                            | `""`      |
+| `configmap.data.data-availability.s3-storage.bucket`                      | s3 bucket                                                                                | `""`      |
+| `configmap.data.data-availability.s3-storage.discard-after-timeout`       | discard after timeout                                                                    | `""`      |
+| `configmap.data.data-availability.s3-storage.object-prefix`               | object prefix                                                                            | `""`      |
+| `configmap.data.data-availability.s3-storage.region`                      | region                                                                                   | `""`      |
+| `configmap.data.data-availability.s3-storage.secret-key`                  | s3 secret key                                                                            | `""`      |
+| `configmap.data.data-availability.ipfs-storage.enable`                    | Enable ipfs storage                                                                      | `false`   |
+| `configmap.data.data-availability.ipfs-storage.profiles`                  | ipfs profiles                                                                            | `""`      |
+| `configmap.data.data-availability.ipfs-storage.read-timeout`              | ipfs read timeout                                                                        | `1m0s`    |
+| `configmap.data.data-availability.local-cache.enable`                     | Enable local cache                                                                       | `false`   |
+| `configmap.data.data-availability.local-cache.capacity`                   | Maximum number of entries (up to 64KB each) to store in the cache.                       | `20000`   |
+| `configmap.data.metrics`                                                  | Enable metrics                                                                           | `false`   |
+| `configmap.data.metrics-server.addr`                                      | Metrics server address                                                                   | `0.0.0.0` |
+| `configmap.data.metrics-server.port`                                      | Metrics server port                                                                      | `6070`    |
+| `configmap.data.metrics-server.update-interval`                           | Metrics server update interval                                                           | `5s`      |
 
 ## Configuration Options
 The following table lists the exhaustive configurable parameters that can be applied as part of the configmap (nested under `configmap.data`) or as standalone cli flags.

--- a/charts/das/ci/sepolia-dac-values.yaml
+++ b/charts/das/ci/sepolia-dac-values.yaml
@@ -9,6 +9,7 @@ configmap:
         data-dir: "/data"
       rest-aggregator:
         enable: true
+        online-url-list: https://nova.arbitrum.io/das-servers
         sync-to-storage:
           eager: true
           eager-lower-bound-block: 15025611

--- a/charts/das/ci/sepolia-dac-values.yaml
+++ b/charts/das/ci/sepolia-dac-values.yaml
@@ -8,6 +8,7 @@ configmap:
         enable: true
         data-dir: "/data"
       rest-aggregator:
+        enable: true
         sync-to-storage:
           eager: true
           eager-lower-bound-block: 15025611

--- a/charts/das/ci/sepolia-das-values.yaml
+++ b/charts/das/ci/sepolia-das-values.yaml
@@ -9,6 +9,7 @@ configmap:
         data-dir: "/data"
       rest-aggregator:
         enable: true
+        online-url-list: https://nova.arbitrum.io/das-servers
         sync-to-storage:
           eager: true
           eager-lower-bound-block: 15025611

--- a/charts/das/ci/sepolia-das-values.yaml
+++ b/charts/das/ci/sepolia-das-values.yaml
@@ -8,6 +8,7 @@ configmap:
         enable: true
         data-dir: "/data"
       rest-aggregator:
+        enable: true
         sync-to-storage:
           eager: true
           eager-lower-bound-block: 15025611

--- a/charts/das/values.yaml
+++ b/charts/das/values.yaml
@@ -255,15 +255,6 @@ configmap:
         enable: false
         capacity: 20000
 
-      rest-aggregator:
-        ## @param configmap.data.data-availability.rest-aggregator.sync-to-storage.eager Enable eagerly syncing batch data to this DAS's storage
-        ## @param configmap.data.data-availability.rest-aggregator.sync-to-storage.state-dir Sync to storage directory
-        ## @param configmap.data.data-availability.rest-aggregator.sync-to-storage.eager-lower-bound-block Start indexing forward from this L1 block
-        sync-to-storage:
-          eager: false
-          eager-lower-bound-block: ""
-          state-dir: ""
-
     ## @param configmap.data.metrics Enable metrics
     metrics: false
 

--- a/charts/das/values.yaml
+++ b/charts/das/values.yaml
@@ -255,6 +255,17 @@ configmap:
         enable: false
         capacity: 20000
 
+      rest-aggregator:
+        ## @param configmap.data.data-availability.rest-aggregator.enable Enable rest aggregator
+        enable: false
+        ## @param configmap.data.data-availability.rest-aggregator.sync-to-storage.eager Enable eagerly syncing batch data to this DAS's storage
+        ## @param configmap.data.data-availability.rest-aggregator.sync-to-storage.state-dir Sync to storage directory
+        ## @param configmap.data.data-availability.rest-aggregator.sync-to-storage.eager-lower-bound-block Start indexing forward from this L1 block
+        sync-to-storage:
+          eager: false
+          eager-lower-bound-block: ""
+          state-dir: ""
+
     ## @param configmap.data.metrics Enable metrics
     metrics: false
 


### PR DESCRIPTION
Disables rest-aggregator explicitly by default in values.yaml to ensure it doesn't get enabled with the default `sync-to-storage.state-dir="", which might crash at start-up`

eg, not sure whether this diff results in setting `rest-aggregator.enable: true` by default (when not explicitly set to false) if `sync-to-storage.state-dir` is ""` 
```
        "rest-aggregator": {
          "sync-to-storage": {
            "eager": false,
            "eager-lower-bound-block": "",
            "state-dir": ""
          }
        },
```