### PR TITLE
Fix dir not found error

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.5.2
+version: 0.5.3
 
 appVersion: "v3.0.3-3ecd01e"

--- a/charts/das/ci/sepolia-dac-values.yaml
+++ b/charts/das/ci/sepolia-dac-values.yaml
@@ -6,7 +6,7 @@ configmap:
       sequencer-inbox-address: "0x6c97864CE4bEf387dE0b3310A44230f7E3F1be0D"
       local-file-storage:
         enable: true
-        data-dir: "/data"
+        data-dir: "/data/das-storage"
       rest-aggregator:
         enable: true
         online-url-list: https://nova.arbitrum.io/das-servers

--- a/charts/das/ci/sepolia-das-values.yaml
+++ b/charts/das/ci/sepolia-das-values.yaml
@@ -6,7 +6,7 @@ configmap:
       sequencer-inbox-address: "0x6c97864CE4bEf387dE0b3310A44230f7E3F1be0D"
       local-file-storage:
         enable: true
-        data-dir: "/data"
+        data-dir: "/data/das-storage"
       rest-aggregator:
         enable: true
         online-url-list: https://nova.arbitrum.io/das-servers

--- a/charts/das/templates/statefulset.yaml
+++ b/charts/das/templates/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-          - mountPath: /data
+          - mountPath: /data/das-storage
             name: localfilestorage
       {{- end }}
       {{- if .Values.initContainers }}

--- a/charts/das/templates/statefulset.yaml
+++ b/charts/das/templates/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-          - mountPath: /data/das-storage
+          - mountPath: /data
             name: localfilestorage
       {{- end }}
       {{- if .Values.initContainers }}


### PR DESCRIPTION
We saw warnings like the following in [CI jobs](https://github.com/OffchainLabs/community-helm-charts/actions/runs/9646762443/job/26603987630?pr=63#step:8:370) for the DAS chart:
```
{"t":"2024-06-24T14:04:18.003300881Z","lvl":"warn","msg":"sync-to-storage failed to write next block number to sync.","err":"open /data/das-storage/syncState/nextBlockNumberV23249278534: no such file or directory","blockNr":6176771}
```
I believe this is due to the init container that creates this directory mounting this volume `/data/das-storage` ([source](https://github.com/OffchainLabs/community-helm-charts/blob/main/charts/das/templates/statefulset.yaml#L50)) slightly differently to the main container `/data` ([source](https://github.com/OffchainLabs/community-helm-charts/blob/main/charts/das/templates/statefulset.yaml#L198) and [source](https://github.com/OffchainLabs/community-helm-charts/blob/66bedb3812748909842cd0d24f7bb319b6d960b3/charts/das/ci/sepolia-dac-values.yaml#L9)). That means the directory is created in the wrong location, I tested this with a similar STS on the lab cluster. Let me know if you'd rather the mount path of the chart's init container was changed instead.