### PR TITLE
fix: Use correct mount path for create-syncstate-directory init container

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.5.12
+version: 0.5.13
 
 appVersion: "v3.2.1-d81324d"

--- a/charts/das/templates/statefulset.yaml
+++ b/charts/das/templates/statefulset.yaml
@@ -13,7 +13,7 @@ spec:
   podManagementPolicy: Parallel
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}
-  updateStrategy: 
+  updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
@@ -53,7 +53,7 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-          - mountPath: /data/das-storage
+          - mountPath: {{ index .Values "configmap" "data" "data-availability" "local-file-storage" "data-dir" }}
             name: localfilestorage
       {{- end }}
       {{- if .Values.initContainers }}


### PR DESCRIPTION
Instead hardcoded `/data/das-storage` mount path use the one provided in config for das helm chart