### PR TITLE
feat(nitro): add sequencer readiness check using maintenance API

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.28
+version: 0.6.29
 
 appVersion: "v3.5.2-33d30c0"

--- a/charts/nitro/templates/statefulset.yaml
+++ b/charts/nitro/templates/statefulset.yaml
@@ -125,7 +125,19 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+            {{- if include "nitro.useSequencerProbe" . | eq "true" }}
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  {{ include "nitro.sequencerReadinessProbeCommand" . | nindent 18 }}
+            {{- with .Values.readinessProbe.sequencerProbe }}
+            {{- omit . "command" "forceEnabled" "disableAutoDetect" | toYaml | nindent 12 }}
+            {{- end }}
+            {{- else }}
+            {{- omit .Values.readinessProbe "enabled" "sequencerProbe" | toYaml | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if and .Values.startupProbe.enabled .Values.configmap.data.http .Values.configmap.data.http.port }}
           startupProbe:

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -26,8 +26,25 @@ commandOverride: {}
 ## @param livenessProbe Liveness probe configuration
 livenessProbe: {}
 
-## @param readinessProbe Readiness probe configuration
-readinessProbe: {}
+## @param readinessProbe.enabled Enable readiness probe
+## @param readinessProbe.sequencerProbe.forceEnabled Force sequencer probe regardless of config detection
+## @param readinessProbe.sequencerProbe.disableAutoDetect Disable auto-detection of sequencer from config
+## @param readinessProbe.sequencerProbe.command Custom command, if empty uses maintenance API check
+readinessProbe:
+  enabled: true
+  # Default probe settings for non-sequencer nodes
+  tcpSocket:
+    port: http-rpc
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  # Sequencer probe settings
+  sequencerProbe:
+    forceEnabled: false
+    disableAutoDetect: false
+    command: ""
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 5
 
 ## @param startupProbe.enabled Enable built in startup probe
 ## @param startupProbe.failureThreshold Number of failures before pod is considered unhealthy


### PR DESCRIPTION
Add conditional readiness probe for sequencer nodes that uses the maintenance API to check if the node is in maintenance mode. This ensures sequencer nodes are only considered ready when not in maintenance mode.

- Add helper functions in _helpers.tpl for sequencer probe detection and command
- Add configuration options in values.yaml for customizing sequencer probe behavior
- Update statefulset.yaml to conditionally apply sequencer readiness probe
- Bump chart version from 0.6.28 to 0.6.29