### PR TITLE
feat(relay): set fallback scrape protocol for relay servicemonitor

### DIFF
--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.5.12
+version: 0.5.13
 
 appVersion: "v3.5.2-33d30c0"

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -181,3 +181,4 @@ Option | Description | Default
 `queue` | int                                                               queue for incoming messages from sequencer | `1024`
 
 ## Notes
+

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -66,6 +66,7 @@ helm install <my-release> offchainlabs/relay \
 | `readinessProbe.periodSeconds`                    | Period for readiness probe                       | `1`                         |
 | `startupProbe.enabled`                            | Enable built in startup probe                    | `false`                     |
 | `serviceMonitor.enabled`                          | Enable prometheus service monitor                | `false`                     |
+| `serviceMonitor.fallbackScrapeProtocol`           | Set the fallback scrape protocol                 | `PrometheusText0.0.4`       |
 | `serviceMonitor.portName`                         | Port name for prometheus service monitor         | `metrics`                   |
 | `serviceMonitor.path`                             | Path for prometheus service monitor              | `/debug/metrics/prometheus` |
 | `serviceMonitor.interval`                         | Interval for prometheus service monitor          | `5s`                        |

--- a/charts/relay/templates/servicemonitor.yaml
+++ b/charts/relay/templates/servicemonitor.yaml
@@ -24,7 +24,7 @@ spec:
       scheme: {{ .Values.serviceMonitor.scheme }}
       {{- end }}
       {{- if .Values.serviceMonitor.tlsConfig }}
-      tlsConfig: 
+      tlsConfig:
         {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 8 }}
       {{- end }}
       {{- with .Values.serviceMonitor.relabelings }}
@@ -36,4 +36,5 @@ spec:
   selector:
     matchLabels:
       {{- include "relay.selectorLabels" . | nindent 6 }}
+  fallbackScrapeProtocol: {{ .Values.serviceMonitor.fallbackScrapeProtocol }}
 {{- end }}

--- a/charts/relay/values.yaml
+++ b/charts/relay/values.yaml
@@ -76,12 +76,14 @@ startupProbe:
   enabled: false
 
 ## @param serviceMonitor.enabled Enable prometheus service monitor
+## @param serviceMonitor.fallbackScrapeProtocol Set the fallback scrape protocol
 ## @param serviceMonitor.portName Port name for prometheus service monitor
 ## @param serviceMonitor.path Path for prometheus service monitor
 ## @param serviceMonitor.interval Interval for prometheus service monitor
 ## @param serviceMonitor.relabelings Add relabelings for the metrics being scraped
 serviceMonitor:
   enabled: false
+  fallbackScrapeProtocol: PrometheusText0.0.4
   portName: metrics
   path: /debug/metrics/prometheus
   interval: 5s


### PR DESCRIPTION
Reason here: https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols