### PR TITLE
chore: update helm charts to nitro v3.5.3

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.5.17
+version: 0.5.18
 
-appVersion: "v3.5.2-33d30c0"
+appVersion: "v3.5.3-0a9c975"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.28
+version: 0.6.29
 
-appVersion: "v3.5.2-33d30c0"
+appVersion: "v3.5.3-0a9c975"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -550,6 +550,7 @@ Option | Description | Default
 `node.bold.delegated-staking.custom-withdrawal-address` | string                                           enable a custom withdrawal address for staking on the rollup contract, useful for delegated stakers | None
 `node.bold.delegated-staking.enable` | enable delegated staking by having the validator call newStake on startup | None
 `node.bold.enable` | enable bold challenge protocol | None
+`node.bold.max-get-log-blocks` | int                                                                       maximum size for chunk of blocks when using get logs rpc | `5000`
 `node.bold.minimum-gap-to-parent-assertion` | duration                                                     minimum duration to wait since the parent assertion was created to post a new assertion | `1m0s`
 `node.bold.rpc-block-number` | string                                                                      define the block number to use for reading data onchain, either latest, safe, or finalized | `finalized`
 `node.bold.start-validation-from-staked` | assume staked nodes are valid | `true`

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.5.13
+version: 0.5.14
 
-appVersion: "v3.5.2-33d30c0"
+appVersion: "v3.5.3-0a9c975"


### PR DESCRIPTION
Updates helm chart versions and app versions to nitro v3.5.3 across DAS, Nitro, and Relay charts.