### PR TITLE
added support for lifecycle hooks, and documented extraEnv in readme.md

### DIFF
--- a/charts/das/README.md
+++ b/charts/das/README.md
@@ -224,6 +224,8 @@ extraEnv:
 | `affinity`                                      | Affinity for the das pod                                                    | `{}`                        |
 | `dasecretName`                                  | Name of the das bls secret that contains the bls key                        | `""`                        |
 | `overrideKeydirMountPath`                       | Override the keydir mount path                                              | `""`                        |
+| `lifecycle`                                     | Configure container lifecycle hooks (postStart, preStop)                    | `{}`                        |
+| `extraEnv`                                      | List of extra environment variables to add to the container                 | `[]`                        |
 
 ### DAS Config options
 

--- a/charts/das/templates/_helpers.tpl
+++ b/charts/das/templates/_helpers.tpl
@@ -82,5 +82,5 @@ curl "http://localhost:{{ index .Values.configmap.data "rpc-port" }}" -X POST \
 {{- define "das.env" -}}
 {{- end -}}
 
-
-
+{{- define "das.lifecycle" -}}
+{{- end -}}

--- a/charts/das/templates/statefulset.yaml
+++ b/charts/das/templates/statefulset.yaml
@@ -195,6 +195,11 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- end }}
+          lifecycle:
+          {{- include "das.lifecycle" . | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- if index .Values "configmap" "data" "data-availability" "local-db-storage" "enable" }}
           - name: localdbstorage

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -174,6 +174,8 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `configmap.data.ws.port`                                   | Port to bind ws service to                                                      | `8548`                                                              |
 | `configmap.data.ws.rpcprefix`                              | Prefix for rpc calls                                                            | `/ws`                                                               |
 | `configmap.data.validation.wasm.allowed-wasm-module-roots` | Default flags as of v3.0.0                                                      | `["/home/user/nitro-legacy/machines","/home/user/target/machines"]` |
+| `lifecycle`                                     | Configure container lifecycle hooks (postStart, preStop)                    | `{}`                        |
+| `extraEnv`                                      | List of extra environment variables to add to the container                 | `[]`                        |
 
 ### Stateless Validator
 
@@ -242,6 +244,7 @@ helm install xai offchainlabs/nitro -f values.yaml
 | `validator.splitvalidator.global.extraPorts`                                        | Additional ports for the stateless validator pod                                                  | `[]`                          |
 | `validator.splitvalidator.global.podAnnotations`                                    | Annotations for the stateless validator pod                                                       | `{}`                          |
 | `validator.splitvalidator.global.priorityClassName`                                 | Priority class name for the stateless validator pod                                               | `""`                          |
+| `validator.splitvalidator.global.lifecycle`                                        | Configure container lifecycle hooks (postStart, preStop) for all validator deployments             | `{}`                          |
 
 ## Configuration Options
 The following table lists the exhaustive configurable parameters that can be applied as part of the configmap (nested under `configmap.data`) or as standalone cli flags.

--- a/charts/nitro/templates/_helpers.tpl
+++ b/charts/nitro/templates/_helpers.tpl
@@ -192,3 +192,6 @@ Currently primarily used for stateless validator configuration
 {{- $processed -}}
 
 {{- end -}}
+
+{{- define "nitro.lifecycle" -}}
+{{- end -}}

--- a/charts/nitro/templates/statefulset.yaml
+++ b/charts/nitro/templates/statefulset.yaml
@@ -156,6 +156,11 @@ spec:
           {{- with .Values.extraEnv }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
+          lifecycle:
+          {{- include "nitro.lifecycle" . | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:
           {{- if .Values.jwtSecret.enabled }}

--- a/charts/nitro/templates/validator/deployments.yaml
+++ b/charts/nitro/templates/validator/deployments.yaml
@@ -147,6 +147,11 @@ spec:
           {{- with $mergedValues.extraEnv }}
           {{- toYaml . | nindent 8 }}
           {{- end }}
+        lifecycle:
+          {{- include "nitro.lifecycle" $ | nindent 10 }}
+          {{- with $mergedValues.lifecycle }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         resources:
           {{- with $mergedValues.resources }}
           {{- toYaml . | nindent 10 }}

--- a/charts/relay/README.md
+++ b/charts/relay/README.md
@@ -95,6 +95,8 @@ helm install <my-release> offchainlabs/relay \
 | `tolerations`                                     | Tolerations for the pod                          | `[]`                        |
 | `topologySpreadConstraints`                       | Topology spread constraints for the pod          | `[]`                        |
 | `affinity`                                        | Affinity for the pod                             | `{}`                        |
+| `lifecycle`                                     | Configure container lifecycle hooks (postStart, preStop)                    | `{}`                        |
+| `extraEnv`                                      | List of extra environment variables to add to the container                 | `[]`                        |
 
 ### Relay Configmap
 

--- a/charts/relay/templates/_helpers.tpl
+++ b/charts/relay/templates/_helpers.tpl
@@ -64,7 +64,8 @@ Create the name of the service account to use
 {{- define "relay.env" -}}
 {{- end -}}
 
-
+{{- define "relay.lifecycle" -}}
+{{- end -}}
 
 
 

--- a/charts/relay/templates/deployment.yaml
+++ b/charts/relay/templates/deployment.yaml
@@ -102,6 +102,11 @@ spec:
           {{- toYaml . | nindent 8 }}
           {{- end }}
           {{- end }}
+          lifecycle:
+          {{- include "relay.lifecycle" . | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- if .Values.configmap.enabled }}
           - name: config


### PR DESCRIPTION
As the title says, documented the `.Values.extraEnv` variable that isn't documented currently and added [lifecycle](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) hooks support.

## DAS Output
<details>
  <summary>das.values.yaml</summary>
  
  ```yaml

  lifecycle:
    postStart:
      exec:
        command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
    preStop:
      exec:
        command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
  
  configmap:
    data:
      conf:
        env-prefix: "NITROCI"
      data-availability:
        sequencer-inbox-address: "0x6c97864CE4bEf387dE0b3310A44230f7E3F1be0D"
        local-file-storage:
          enable: true
          data-dir: "/data"
  
  extraEnv:
    - name: NITROCI_DATA__AVAILABILITY_PARENT__CHAIN__NODE__URL
      valueFrom:
        secretKeyRef:
          name: ci-secret-nitro
          key: PARENT_CHAIN_URL_SEPOLIA
  
  ci:
    secretManifest:
      enabled: true
  ```

</details>

<details>
  <summary>das.output.yaml</summary>
  
  ```yaml
 ---
  # Source: das/templates/statefulset.yaml
  apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: das
    labels:
      helm.sh/chart: das
      app.kubernetes.io/name: das
      app.kubernetes.io/instance: das
      app.kubernetes.io/version: "v3.5.5-90ee45c"
      app.kubernetes.io/managed-by: Helm
  spec:
    serviceName: "das"
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: das
        app.kubernetes.io/instance: das
    podManagementPolicy: Parallel
    updateStrategy:
      type: RollingUpdate
    template:
      metadata:
        annotations:
          checksum/configmap: 2828f8521ec4d33378af4811979909b3d2128388d85446bd9153ea189db12ad4
        labels:
          app.kubernetes.io/name: das
          app.kubernetes.io/instance: das
      spec:
        serviceAccountName: das
        securityContext:
  
          fsGroup: 1000
          fsGroupChangePolicy: OnRootMismatch
          runAsGroup: 1000
          runAsNonRoot: true
          runAsUser: 1000
        initContainers:
        containers:
          - name: das
            securityContext:
              {}
            image: "offchainlabs/nitro-node:v3.5.5-90ee45c"
            imagePullPolicy: Always
            command: [/usr/local/bin/daserver]
            args:
              - --conf.file=/config/config.json
            ports:
              - name: http-rest
                containerPort: 9877
                protocol: TCP
            livenessProbe:
              initialDelaySeconds: 60
              periodSeconds: 60
              timeoutSeconds: 5
              failureThreshold: 3
              successThreshold: 1
              httpGet:
                path: /health
                port: 9877
            readinessProbe:
              initialDelaySeconds: 0
              periodSeconds: 5
              timeoutSeconds: 5
              failureThreshold: 3
              successThreshold: 1
              httpGet:
                path: /health
                port: 9877
            env:
  
            - name: NITROCI_DATA__AVAILABILITY_PARENT__CHAIN__NODE__URL
              valueFrom:
                secretKeyRef:
                  key: PARENT_CHAIN_URL_SEPOLIA
                  name: ci-secret-nitro
            lifecycle:
  
              postStart:
                exec:
                  command:
                  - /bin/sh
                  - -c
                  - echo Hello from the postStart handler > /usr/share/message
              preStop:
                exec:
                  command:
                  - /bin/sh
                  - -c
                  - nginx -s quit; while killall -0 nginx; do sleep 1; done
            volumeMounts:
            - name: localfilestorage
              mountPath: /data
            - name: config
              mountPath: /config/
            resources:
              {}
        volumes:
        - name: config
          configMap:
            name: das
  
        terminationGracePeriodSeconds: 600
    volumeClaimTemplates:
      - metadata:
          name: localfilestorage
          labels:
            app: das
            release: das
            heritage: Helm
        spec:
          accessModes:
          - ReadWriteOnce
          resources:
            requests:
  ```

</details>

## Nitro Output

<details>
  <summary>nitro.values.yaml</summary>
  
  ```yaml
  lifecycle:
    postStart:
      exec:
        command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
    preStop:
      exec:
        command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
  
  startupProbe:
    enabled: false
  
  diagnosticMode: false
  
  readinessProbe:
    enabled: true
    tcpSocket:
      port: http-rpc
    initialDelaySeconds: 10
    periodSeconds: 3
  
  jwtSecret:
    enabled: true
    value: "9911e3404a316d61ddbda18b1d23479002535efebb7a4c8dbc3408a1d9ac6b06"
  
  blobPersistence:
    enabled: true
  
  validator:
    enabled: true
  
    splitvalidator:
      deployments:
        - name: "1"
        - name: "2"
  
      global:
        lifecycle:
          postStart:
            exec:
              command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
          preStop:
            exec:
              command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
        configmap:
          data:
            metrics: true
        resources:
          limits:
            memory: 8Gi
  
        metrics:
          enabled: true
  
  resources:
    limits:
      memory: 8Gi
  
  env:
    resourceMgmtMemFreeLimit:
      enabled: true
    blockValidatorMemFreeLimit:
      enabled: true
  
  configmap:
    data:
      conf:
        env-prefix: "NITROCI"
      chain:
        id: 421614
      node:
        staker:
          enable: true
          parent-chain-wallet:
            account: "44a2864f7e5fc6ac1704ffae163730ad66d02fc1"
            password: "test123"
      parent-chain:
        id: 11155111
        blob-client:
          blob-directory: /home/user/blobdata/
      metrics: true
      execution:
        tx-pre-checker:
          strictness: 0
  
  wallet:
    files:
      key1.json: '{"address":"44a2864f7e5fc6ac1704ffae163730ad66d02fc1","id":"0410ec05-04c1-47fa-bb1f-e14a8fa7c54b","version":3,"Crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"6cceaacd065a07ae7cc6cf9856f4e5fe"},"ciphertext":"33549ecaa70a3f31c9fbd16ecd93a9ddfcd5bbfde87420e3843312509d16002d","kdf":"scrypt","kdfparams":{"salt":"25a8b71f4fa6593753783746ed6a072b43713a8226b39855e35c8855690e3226","n":131072,"dklen":32,"p":1,"r":8},"mac":"56a7de08e50295f976bbfb71a4125379cf7d00ee0171c7fb43dd3aafdf770649"},"x-ethers":{"client":"ethers/6.12.1","gethFilename":"UTC--2024-05-07T05-35-58.0Z--44a2864f7e5fc6ac1704ffae163730ad66d02fc1","path":"m/44''/60''/0''/0/0","locale":"en","mnemonicCounter":"9810530864bddf04b8fee8b9e535fcdc","mnemonicCiphertext":"9f46a31391cca84a2dc361255e5ff467","version":"0.1"}}'
  
  extraEnv:
    - name: NITROCI_PARENT__CHAIN_CONNECTION_URL
      valueFrom:
        secretKeyRef:
          name: ci-secret-nitro
          key: PARENT_CHAIN_URL_SEPOLIA
    - name: NITROCI_PARENT__CHAIN_BLOB__CLIENT_BEACON__URL
      valueFrom:
        secretKeyRef:
          name: ci-secret-nitro
          key: PARENT_CHAIN_BLOB_CLIENT_URL
  
  ci:
    nitro-secret:
      enabled: true
    logLevel: INFO
  
    rpc:
      baselineUrl: https://sepolia-rollup.arbitrum.io/rpc/$BASELINE_RPC_KEY_SEPOLIA
      url: $RPC_URL
  
    testAccount:
      privateKey: $TEST_ACCOUNT_PRIVATE_KEY
    secretManifest:
      enabled: true
  ```

</details>

<details>
  <summary>nitro.output.yaml</summary>
  
  ```yaml
  # Source: nitro/templates/validator/deployments.yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nitro-val-2
    labels:
      helm.sh/chart: nitro
      app.kubernetes.io/name: nitro
      app.kubernetes.io/instance: nitro
      app.kubernetes.io/version: "v3.5.5-90ee45c"
      app.kubernetes.io/managed-by: Helm
  spec:
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: nitro
        app.kubernetes.io/instance: nitro
        validator: "2"
    template:
      metadata:
        annotations:
          checksum/configmap: 5742a913c6451ad770a09ac0c36298a02b954597467a41e6daaec6aa26cdfd15
        labels:
          app.kubernetes.io/name: nitro
          app.kubernetes.io/instance: nitro
          validator: "2"
          function: split-validator
      spec:
        serviceAccountName: nitro
        nodeSelector:
          kubernetes.io/arch: amd64
        terminationGracePeriodSeconds: 60
        affinity:
        tolerations:
        topologySpreadConstraints:
        securityContext:
        initContainers:
        containers:
        - name: nitro-stateless
          image: "offchainlabs/nitro-node:v3.5.5-90ee45c"
          command: ["/usr/local/bin/nitro-val"]
          args:
            - --metrics
            - --conf.file=/config/config.json
          ports:
            - name: auth
              containerPort: 8549
            - name: metrics
              containerPort: 6070
              protocol: TCP
          volumeMounts:
            - name: jwt-secret
              mountPath: /secrets/jwtsecret
              subPath: jwtSecret
              readOnly: true
            - name: nitro-val-2
              mountPath: /config/
          livenessProbe:
            initialDelaySeconds: 30
            periodSeconds: 10
            tcpSocket:
              port: auth
          readinessProbe:
            initialDelaySeconds: 3
            periodSeconds: 3
            tcpSocket:
              port: auth
          startupProbe:
          env:
  
          - name: GOMEMLIMIT
            value: 6144MiB
          lifecycle:
  
            postStart:
              exec:
                command:
                - /bin/sh
                - -c
                - echo Hello from the postStart handler > /usr/share/message
            preStop:
              exec:
                command:
                - /bin/sh
                - -c
                - nginx -s quit; while killall -0 nginx; do sleep 1; done
          resources:
            limits:
              memory: 8Gi
        volumes:
          - name: jwt-secret
            secret:
              secretName: nitro-jwt
          - name: nitro-val-2
            configMap:
              name: nitro-val-2
  ---
  # Source: nitro/templates/statefulset.yaml
  apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: nitro
    labels:
      helm.sh/chart: nitro
      app.kubernetes.io/name: nitro
      app.kubernetes.io/instance: nitro
      app.kubernetes.io/version: "v3.5.5-90ee45c"
      app.kubernetes.io/managed-by: Helm
    annotations:
      nitro.arbitrum.io/desiredReplicas: "1"
  spec:
    serviceName: nitro-headless
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: nitro
        app.kubernetes.io/instance: nitro
    podManagementPolicy: Parallel
    updateStrategy:
      type: RollingUpdate
    template:
      metadata:
        annotations:
          checksum/configmap: 53e3e412f69e8db02409136e2b62f9c954466e3d6e85fcc86a225676ce6cc8a9
          checksum/wallets: 6ca1847f5c8ae08580ba5103cd0277c7aaa2e2057c82d6168112c3c0a32dae2f
        labels:
          app.kubernetes.io/name: nitro
          app.kubernetes.io/instance: nitro
          function: nitro
      spec:
        serviceAccountName: nitro
        securityContext:
  
          fsGroup: 1000
          fsGroupChangePolicy: OnRootMismatch
          runAsGroup: 1000
          runAsNonRoot: true
          runAsUser: 1000
        initContainers:
  
        containers:
          - name: nitro
            securityContext:
              {}
            image: "offchainlabs/nitro-node:v3.5.5-90ee45c"
            imagePullPolicy: Always
            command: [/usr/local/bin/nitro]
            args:
              - --metrics
              - --conf.file=/config/config.json
            ports:
              - name: http-rpc
                containerPort: 8547
                protocol: TCP
              - name: ws
                containerPort: 8548
                protocol: TCP
              - name: metrics
                containerPort: 6070
                protocol: TCP
            readinessProbe:
              initialDelaySeconds: 10
              periodSeconds: 3
              tcpSocket:
                port: http-rpc
            env:
              - name: POD_NAME
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.name
              - name: POD_NAMESPACE
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.namespace
              - name: POD_IP
                valueFrom:
                  fieldRef:
                    fieldPath: status.podIP
  
              - name: GOMEMLIMIT
                value: 7372MiB
              - name: NITROCI_NODE_RESOURCE__MGMT_MEM__FREE__LIMIT
                value: 429496729B
              - name: NITROCI_NODE_BLOCK__VALIDATOR_MEMORY__FREE__LIMIT
                value: 429496729B
              - name: NITROCI_PARENT__CHAIN_CONNECTION_URL
                valueFrom:
                  secretKeyRef:
                    key: PARENT_CHAIN_URL_SEPOLIA
                    name: ci-secret-nitro
              - name: NITROCI_PARENT__CHAIN_BLOB__CLIENT_BEACON__URL
                valueFrom:
                  secretKeyRef:
                    key: PARENT_CHAIN_BLOB_CLIENT_URL
                    name: ci-secret-nitro
            lifecycle:
  
              postStart:
                exec:
                  command:
                  - /bin/sh
                  - -c
                  - echo Hello from the postStart handler > /usr/share/message
              preStop:
                exec:
                  command:
                  - /bin/sh
                  - -c
                  - nginx -s quit; while killall -0 nginx; do sleep 1; done
            volumeMounts:
            - name: jwt-secret
              mountPath: /secrets/jwtsecret
              subPath: jwtSecret
              readOnly: true
            - name: nitrodata
              mountPath: /home/user/data/
            - name: nitroblobdata
              mountPath: /home/user/blobdata/
            - name: config
              mountPath: /config/
  
            - name: wallet-files
              mountPath: /wallet/key1.json
              subPath: key1.json
            resources:
              limits:
                memory: 8Gi
  
        volumes:
        - name: jwt-secret
          secret:
            secretName: nitro-jwt
        - name: config
          configMap:
            name: nitro
        - name: wallet-files
          secret:
            secretName: nitro-wallets
        nodeSelector:
          kubernetes.io/arch: amd64
        terminationGracePeriodSeconds: 600
    volumeClaimTemplates:
      - metadata:
          name: nitrodata
          labels:
            app: nitro
            release: nitro
            heritage: Helm
        spec:
          accessModes:
          - ReadWriteOnce
          resources:
            requests:
              storage: "500Gi"
      - metadata:
          name: nitroblobdata
          labels:
            app: nitro
            release: nitro
            heritage: Helm
        spec:
          accessModes:
          - ReadWriteOnce
          resources:
            requests:
              storage: "100Gi"
  ---
  # Source: nitro/templates/tests/test.yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: "nitro-ci-configmap"
    annotations:
      "helm.sh/hook": test
  data:
    config.yaml: |
      debug:
        enabled: false
      logLevel: INFO
      nitro-secret:
        enabled: true
      rpc:
        baselineUrl: https://sepolia-rollup.arbitrum.io/rpc/$BASELINE_RPC_KEY_SEPOLIA
        url: $RPC_URL
      secretManifest:
        enabled: true
      testAccount:
        privateKey: $TEST_ACCOUNT_PRIVATE_KEY
  ---
  # Source: nitro/templates/tests/test.yaml
  apiVersion: v1
  kind: Pod
  metadata:
    name: "nitro-nitro-test"
    labels:
      helm.sh/chart: nitro
      app.kubernetes.io/name: nitro
      app.kubernetes.io/instance: nitro
      app.kubernetes.io/version: "v3.5.5-90ee45c"
      app.kubernetes.io/managed-by: Helm
    annotations:
      "helm.sh/hook": test
  spec:
    containers:
    - name: sre-nitro-test-suite
      image: public.ecr.aws/f6s7v9z5/offchain-labs/sre-nitro-test:v0.0.7
      imagePullPolicy: Always
      volumeMounts:
      - name: config-volume
        mountPath: "/config"
        readOnly: true
      envFrom:
      - secretRef:
          name: "ci-secret-nitro"
      env:
      - name: RPC_URL
        value: http://nitro:8547/rpc
    volumes:
    - name: config-volume
      configMap:
        name: "nitro-ci-configmap"
  
    restartPolicy: Never
  ```

</details>

## Relay Output
<details>
  <summary>relay.values.yaml</summary>
  
  ```yaml
  lifecycle:
    postStart:
      exec:
        command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
    preStop:
      exec:
        command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
  
  configmap:
    data:
      node:
        feed:
          input:
            url: wss://sepolia-rollup.arbitrum.io/feed
  ```

</details>

<details>
  <summary>relay.output.yaml</summary>
  
  ```yaml
  ---
  # Source: relay/templates/deployment.yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: relay
    labels:
      helm.sh/chart: relay
      app.kubernetes.io/name: relay
      app.kubernetes.io/instance: relay
      app.kubernetes.io/version: "v3.5.5-90ee45c"
      app.kubernetes.io/managed-by: Helm
  spec:
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: relay
        app.kubernetes.io/instance: relay
    template:
      metadata:
        annotations:
          checksum/configmap: 55e897b1df3b94a691a6845fc7b91839f5c8fb309ad78d3396831eda8096b877
        labels:
          app.kubernetes.io/name: relay
          app.kubernetes.io/instance: relay
      spec:
        serviceAccountName: relay
        securityContext:
  
          fsGroup: 1000
          fsGroupChangePolicy: OnRootMismatch
          runAsGroup: 1000
          runAsNonRoot: true
          runAsUser: 1000
        containers:
          - name: relay
            securityContext:
              {}
            image: "offchainlabs/nitro-node:v3.5.5-90ee45c"
            imagePullPolicy: Always
            command: [/usr/local/bin/relay]
            args:
              - --conf.file=/config/config.json
            ports:
              - name: feed
                containerPort: 9642
                protocol: TCP
            livenessProbe:
              httpGet:
                path: /livenessprobe
                port: feed
              initialDelaySeconds: 10
              periodSeconds: 1
            readinessProbe:
              initialDelaySeconds: 20
              periodSeconds: 1
              tcpSocket:
                port: feed
            env:
  
            lifecycle:
  
              postStart:
                exec:
                  command:
                  - /bin/sh
                  - -c
                  - echo Hello from the postStart handler > /usr/share/message
              preStop:
                exec:
                  command:
                  - /bin/sh
                  - -c
                  - nginx -s quit; while killall -0 nginx; do sleep 1; done
            volumeMounts:
            - name: config
              mountPath: /config/
            resources:
              {}
        volumes:
        - name: config
          configMap:
            name: relay
  ```

</details>
