### PR TITLE
chore: update nitro image to v3.6.8-d6c96a5

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.3
+version: 0.6.4
 
-appVersion: "v3.6.7-a7c9f1e"
+appVersion: "v3.6.8-d6c96a5"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.6
+version: 0.7.7
 
-appVersion: "v3.6.7-a7c9f1e"
+appVersion: "v3.6.8-d6c96a5"

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.3
+version: 0.6.4
 
-appVersion: "v3.6.7-a7c9f1e"
+appVersion: "v3.6.8-d6c96a5"


### PR DESCRIPTION
## Summary
- Updated nitro image from v3.6.7-a7c9f1e to v3.6.8-d6c96a5
- Bumped chart versions for nitro, relay, and das charts