### PR TITLE
feat(nitro): add env-prefix validation to prevent configuration conflicts

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.7
+version: 0.7.8
 
 appVersion: "v3.6.8-d6c96a5"

--- a/charts/nitro/templates/_helpers.tpl
+++ b/charts/nitro/templates/_helpers.tpl
@@ -98,6 +98,12 @@ nitro args
 {{- fail "configmap.data.conf.env-prefix must be set when goMemLimit is enabled" -}}
 {{- end -}}
 
+{{/* Validate env-prefix doesn't conflict with service names */}}
+{{- $fullName := include "nitro.fullname" . -}}
+{{- if and $envPrefix (hasPrefix (upper $envPrefix) (upper $fullName)) -}}
+{{- fail (printf "configmap.data.conf.env-prefix '%s' conflicts with service name '%s'. This will cause Kubernetes service environment variables like %s_SERVICE_HOST to be interpreted as configuration keys. Use a different env-prefix or release name." $envPrefix $fullName (upper $fullName)) -}}
+{{- end -}}
+
 {{/* Memory-based environment variables */}}
 {{- if and .Values.resources .Values.resources.limits .Values.resources.limits.memory .Values.env.nitro.goMemLimit.enabled -}}
 {{- $memory := .Values.resources.limits.memory -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds validation to detect when `env-prefix` conflicts with service names, preventing Kubernetes service environment variables from being interpreted as configuration keys. This resolves cryptic configuration errors when release names start with the env-prefix (e.g., using `env-prefix: "NITRO"` with release name `nitro-sepolia` causes `NITRO_SEPOLIA_SERVICE_HOST` to be parsed as config key `sepolia`).

#### Which issue this PR fixes

Fixes configuration conflicts that cause nitro nodes to crash with "invalid keys" errors when service names conflict with env-prefix.

#### Special notes for your reviewer:

- The validation only runs when `env-prefix` is set, allowing flexibility for deployments that don't use environment variable configuration
- Error message provides clear guidance on how to resolve the conflict
- Chart version bumped to 0.7.8

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] CI checks pass
- [x] Chart Version bumped
- [x] Variables are tagged appropriately (used for generating the README)