### PR TITLE
feat(nitro): add configmap.removeKeys to remove config entries

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.9
+version: 0.7.10
 
 appVersion: "v3.6.8-d6c96a5"

--- a/charts/nitro/ci/sepolia-values.yaml
+++ b/charts/nitro/ci/sepolia-values.yaml
@@ -47,6 +47,12 @@ env:
     enabled: true
 
 configmap:
+  # Test removeKeys feature - remove bogus/test fields that don't affect functionality
+  removeKeys:
+    - "test-section"
+    - "deprecated-feature"
+    - "node.legacy-option"
+
   data:
     conf:
       env-prefix: "NITROCI"
@@ -58,6 +64,8 @@ configmap:
         parent-chain-wallet:
           account: "44a2864f7e5fc6ac1704ffae163730ad66d02fc1"
           password: "test123"
+      # Add bogus field to test removal
+      legacy-option: "should-be-removed"
     parent-chain:
       id: 11155111
       blob-client:
@@ -66,6 +74,11 @@ configmap:
     execution:
       tx-pre-checker:
         strictness: 0
+    # Add bogus sections to test removal
+    test-section:
+      dummy: "value"
+      another: "field"
+    deprecated-feature: true
 
 wallet:
   files:

--- a/charts/nitro/templates/_helpers.tpl
+++ b/charts/nitro/templates/_helpers.tpl
@@ -322,6 +322,40 @@ Currently primarily used for stateless validator configuration
   {{- end -}}
 {{- end -}}
 
+{{- /* Process removals if specified */ -}}
+{{- if .Values.configmap.removeKeys -}}
+  {{- /* Process each removal key */ -}}
+  {{- range .Values.configmap.removeKeys -}}
+    {{- $keyPath := . -}}
+    {{- $keys := splitList "." $keyPath -}}
+    
+    {{- /* Navigate to the parent of the key to remove */ -}}
+    {{- $current := $values.configmap.data -}}
+    {{- $parent := dict -}}
+    {{- $parentKey := "" -}}
+    
+    {{- /* Navigate through the path */ -}}
+    {{- range $index, $key := $keys -}}
+      {{- if lt $index (sub (len $keys) 1) -}}
+        {{- /* Not the last key - navigate deeper */ -}}
+        {{- if hasKey $current $key -}}
+          {{- $parent = $current -}}
+          {{- $parentKey = $key -}}
+          {{- $current = index $current $key -}}
+        {{- else -}}
+          {{- /* Path doesn't exist, break */ -}}
+          {{- break -}}
+        {{- end -}}
+      {{- else -}}
+        {{- /* This is the last key - remove it */ -}}
+        {{- if hasKey $current $key -}}
+          {{- $_ := unset $current $key -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- /* Process the final configmap data into pretty JSON format */ -}}
 {{- $processed := $values.configmap.data | toPrettyJson | replace "\\u0026" "&" | replace "\\u003c" "<" | replace "\\u003e" ">" -}}
 

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -248,6 +248,8 @@ enableAutoConfigProcessing: true
 configmap:
   ## @param configmap.enabled Enable a configmap for the nitro container
   enabled: true
+  ## @param configmap.removeKeys List of keys to remove from the config (dot-separated paths, e.g., "metrics-server.port")
+  removeKeys: []
   ## @extra configmap.data See Configuration Options for the full list of options
   data:
     ## @param configmap.data.conf.env-prefix Environment variable prefix


### PR DESCRIPTION
## Summary
- Add `configmap.removeKeys` feature to allow removing configuration entries entirely
- Helps with backwards compatibility when nitro releases have different CLI arguments
- Add CI testing to verify the functionality

## Features
- Support removing entire config sections (e.g., `"ws"`, `"pprof"`)
- Support removing nested fields using dot notation (e.g., `"metrics-server.port"`)
- Add CI testing with bogus fields to verify functionality

## Example usage
```yaml
configmap:
  removeKeys:
    - "deprecated-section"
    - "node.old-field"
```

## Test plan
- [x] Added bogus test fields to `charts/nitro/ci/sepolia-values.yaml` 
- [x] Verified the removeKeys functionality works with helm template
- [ ] CI will test the feature automatically with the sepolia values