### PR TITLE
chore: remove app.kubernetes.io/version label from all charts

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.4
+version: 0.6.5
 
 appVersion: "v3.6.8-d6c96a5"

--- a/charts/das/templates/_helpers.tpl
+++ b/charts/das/templates/_helpers.tpl
@@ -36,9 +36,6 @@ Common labels
 {{- define "das.labels" -}}
 helm.sh/chart: {{ include "das.chart" . }}
 {{ include "das.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.9
+version: 0.7.10
 
 appVersion: "v3.6.8-d6c96a5"

--- a/charts/nitro/templates/_helpers.tpl
+++ b/charts/nitro/templates/_helpers.tpl
@@ -36,9 +36,6 @@ Common labels
 {{- define "nitro.labels" -}}
 helm.sh/chart: {{ include "nitro.chart" . }}
 {{ include "nitro.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.4
+version: 0.6.5
 
 appVersion: "v3.6.8-d6c96a5"

--- a/charts/relay/templates/_helpers.tpl
+++ b/charts/relay/templates/_helpers.tpl
@@ -36,9 +36,6 @@ Common labels
 {{- define "relay.labels" -}}
 helm.sh/chart: {{ include "relay.chart" . }}
 {{ include "relay.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
## Summary
Remove the `app.kubernetes.io/version` label from all charts to avoid unnecessary diffs when appVersion changes.

## Changes
- Remove `app.kubernetes.io/version` label from common labels in:
  - nitro chart
  - relay chart  
  - das chart
- Bump chart versions:
  - nitro: 0.7.9 -> 0.7.10
  - relay: 0.6.4 -> 0.6.5
  - das: 0.6.4 -> 0.6.5

## Why?
The `app.kubernetes.io/version` label creates unnecessary diffs in deployed resources whenever the appVersion changes, even if there are no other changes to the deployment. This label is not required and removing it simplifies upgrades.

## Test plan
- [x] Verified helm template renders without the version label for all charts
- [x] No errors when generating templates