### PR TITLE
Update nitro charts to v3.7.1

### DIFF
--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -9,4 +9,4 @@ type: application
 
 version: 0.6.6
 
-appVersion: "v3.7.0-6d34456"
+appVersion: "v3.7.1-926f1ab"

--- a/charts/das/Chart.yaml
+++ b/charts/das/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.6
+version: 0.6.7
 
 appVersion: "v3.7.1-926f1ab"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -9,4 +9,4 @@ type: application
 
 version: 0.7.12
 
-appVersion: "v3.7.0-6d34456"
+appVersion: "v3.7.1-926f1ab"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.12
+version: 0.7.13
 
 appVersion: "v3.7.1-926f1ab"

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -779,7 +779,7 @@ Option | Description | Default
 `node.staker.data-poster.use-noop-storage` | uses noop storage, it doesn't store anything | None
 `node.staker.data-poster.wait-for-l1-finality` | only treat a transaction as confirmed after L1 finality has been achieved (recommended) | `true`
 `node.staker.disable-challenge` | disable validator challenge | None
-`node.staker.enable` | enable validator | `true`
+`node.staker.enable` | Version: v3.7.1-926f1ab, time: 2025-08-27T10:08:27-03:00  enable validator (default true) | None
 `node.staker.enable-fast-confirmation` | enable fast confirmation | None
 `node.staker.extra-gas` | uint                                                                             use this much more gas than estimation says is necessary to post transactions | `50000`
 `node.staker.gas-refunder-address` | string                                                                The gas refunder contract address (optional) | None

--- a/charts/nitro/README.md
+++ b/charts/nitro/README.md
@@ -779,7 +779,7 @@ Option | Description | Default
 `node.staker.data-poster.use-noop-storage` | uses noop storage, it doesn't store anything | None
 `node.staker.data-poster.wait-for-l1-finality` | only treat a transaction as confirmed after L1 finality has been achieved (recommended) | `true`
 `node.staker.disable-challenge` | disable validator challenge | None
-`node.staker.enable` | Version: v3.7.1-926f1ab, time: 2025-08-27T10:08:27-03:00  enable validator (default true) | None
+`node.staker.enable` | enable validator | `true`
 `node.staker.enable-fast-confirmation` | enable fast confirmation | None
 `node.staker.extra-gas` | uint                                                                             use this much more gas than estimation says is necessary to post transactions | `50000`
 `node.staker.gas-refunder-address` | string                                                                The gas refunder contract address (optional) | None

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -9,4 +9,4 @@ type: application
 
 version: 0.6.6
 
-appVersion: "v3.7.0-6d34456"
+appVersion: "v3.7.1-926f1ab"

--- a/charts/relay/Chart.yaml
+++ b/charts/relay/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.6.6
+version: 0.6.7
 
 appVersion: "v3.7.1-926f1ab"


### PR DESCRIPTION
Issue: https://linear.app/offchain-labs/issue/SREP-1580/update-community-helm-charts-to-371
Release: https://github.com/OffchainLabs/nitro/releases/tag/v3.7.1