### PR TITLE
feat(nitro): add a default resource.requests.ephemeral-storage

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.13
+version: 0.7.14
 
 appVersion: "v3.7.1-926f1ab"

--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -7,6 +7,6 @@ maintainers:
 
 type: application
 
-version: 0.7.14
+version: 0.7.15
 
 appVersion: "v3.7.3-e421729"

--- a/charts/nitro/values.yaml
+++ b/charts/nitro/values.yaml
@@ -213,7 +213,11 @@ service:
   loadBalancerSourceRanges: null
 
 ## @param resources Resources for the container
-resources: {}
+resources:
+  ## @param resources.requests Resource requests for the container
+  requests:
+    ephemeral-storage: 100Mi
+
 
 ## @param nodeSelector Node selector for the pod
 nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a sensible default ephemeral-storage resource request to the nitro container to ensure it has enough local, node-attached storage to function properly.

#### Which issue this PR fixes
Fixes an issue where the nitro pod can be rescheduled due to exceeding it's requested ephemeral-storage when the node it's running on is low on ephemeral-storage

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] CI checks pass
- [x] Chart Version bumped
