### PR TITLE
fix(ci): create passing status check for PRs without chart changes

### DIFF
--- a/.github/workflows/test-charts-status.yaml
+++ b/.github/workflows/test-charts-status.yaml
@@ -17,7 +17,7 @@ jobs:
       # We don't check out any code here for security
       - name: Check if charts were modified
         id: check-charts
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
           script: |
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create success status (no chart changes)
         if: steps.check-charts.outputs.has_chart_changes == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
           script: |
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create pending status (chart changes detected)
         if: steps.check-charts.outputs.has_chart_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
           script: |


### PR DESCRIPTION
## Summary
- The `Chart Installation Test` status check is required by branch protection on `main`
- This check was previously only created for PRs that modify `charts/**` files
- PRs that only modify workflow files, docs, or other non-chart files would be permanently blocked because the required check never appeared

## Changes
- Removed the `paths: charts/**` filter from `test-charts-status.yaml` so it triggers on ALL PRs
- Added a step to detect whether charts were actually modified using the GitHub API
- If no charts modified: immediately creates a passing `Chart Installation Test` check
- If charts modified: creates an in-progress check (existing behavior, completed by the privileged workflow)

## Test Plan
- [ ] Open a PR that only modifies workflow files (no chart changes) — verify the `Chart Installation Test` check appears and shows as passed with message "No chart changes detected"
- [ ] Open a PR that modifies charts — verify the check still shows as "in progress" and completes normally via the privileged test workflow
- [ ] Verify existing PRs (#310, etc.) get unblocked after this fix is merged