### PR TITLE
fix: restore docker-user: root in Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -51,9 +51,8 @@ jobs:
           token: ${{ steps.generate-token.outputs.token || secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
           renovate-version: 41.59.0
           docker-cmd-file: .github/renovate-entrypoint.sh
-          # NOTE: docker-user: root and mount-docker-socket: true have been
-          # removed for security. If Renovate needs Docker access (e.g., for
-          # post-upgrade tasks), re-enable with documented justification.
+          docker-user: root  # Required: entrypoint installs packages via apt-get and writes to /usr/local/bin/
+          # mount-docker-socket removed: not needed (entrypoint doesn't use Docker)
           env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN)$"
         env:
           # Core configuration


### PR DESCRIPTION
## Summary

- Restores `docker-user: root` in the Renovate workflow, which was accidentally removed when PR #316 was merged before the corrective fix was pushed
- Keeps `mount-docker-socket: true` removed (not needed by the entrypoint)

## Root Cause

PR #316 (security hardening) initially removed both `docker-user: root` and `mount-docker-socket: true`. Renovate CI failed because the entrypoint script (`.github/renovate-entrypoint.sh`) requires root to:
- Run `apt-get update` / `apt-get install`
- Write binaries to `/usr/local/bin/` (yq, helm)

The fix was force-pushed to the branch, but the original (broken) version had already been merged to main.

## Test Plan

- [ ] Trigger Renovate workflow manually via `workflow_dispatch` and verify it completes successfully
- [ ] Confirm the entrypoint script can install packages (`apt-get install python3`) without permission errors
- [ ] Verify `mount-docker-socket` remains removed (not present in the workflow file)

## Evidence

Renovate CI failure log from the broken version:
```
E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
```

The entrypoint script requires root:
```bash
apt-get update
apt-get install -y python3
# ... writes to /usr/local/bin/
```