### PR TITLE
fix(ci): restore mount-docker-socket for Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -52,7 +52,7 @@ jobs:
           renovate-version: 41.59.0
           docker-cmd-file: .github/renovate-entrypoint.sh
           docker-user: root  # Required: entrypoint installs packages via apt-get and writes to /usr/local/bin/
-          # mount-docker-socket removed: not needed (entrypoint doesn't use Docker)
+          mount-docker-socket: true  # Required: readmecli.py runs `docker run` to scrape CLI --help output
           env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN)$"
         env:
           # Core configuration


### PR DESCRIPTION
## Summary
- Restores `mount-docker-socket: true` to the Renovate GitHub Action, which was removed in #316

## Context
PR #316 removed `mount-docker-socket` assuming Docker wasn't used by the entrypoint. However, `readmecli.py` (invoked via `postUpgradeTasks` in `renovate-update-all-charts.sh`) runs `docker run ... --help` to scrape CLI flags from the nitro-node image for README generation.

Without the Docker socket, `docker run` fails silently and the script writes empty CLI args tables, wiping all configuration documentation from the chart READMEs. This is the root cause of the bad diff in #322.

## Test plan
- [ ] Trigger Renovate workflow via workflow_dispatch and verify it completes successfully
- [ ] Verify the next Renovate PR for nitro-node includes proper README CLI args tables