### PR TITLE
fix(ci): capture ct install exit code so failures are reported

### DIFF
--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -100,8 +100,9 @@ jobs:
         id: chart-test
         continue-on-error: true
         run: |
-          ct install --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml --helm-extra-set-args "$HELM_EXTRA_SET_ARGS"
-          echo "CT_EXIT_CODE=$?" >> $GITHUB_ENV
+          EXIT=0
+          ct install --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml --helm-extra-set-args "$HELM_EXTRA_SET_ARGS" || EXIT=$?
+          echo "CT_EXIT_CODE=$EXIT" >> $GITHUB_ENV
 
       - name: Determine test status
         id: test-status
@@ -109,7 +110,7 @@ jobs:
           if [[ "$HAS_CHANGES" == "false" ]]; then
             echo "STATUS=success" >> $GITHUB_ENV
             echo "STATUS_TEXT=No chart changes detected" >> $GITHUB_ENV
-          elif [[ "${CT_EXIT_CODE:-0}" == "0" ]]; then
+          elif [[ "${CT_EXIT_CODE:-1}" == "0" ]]; then
             echo "STATUS=success" >> $GITHUB_ENV
             echo "STATUS_TEXT=succeeded" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## Summary

- `ct install` failures in [.github/workflows/test-install.yaml](.github/workflows/test-install.yaml) were silently reported as success. GitHub composite `run:` blocks default to `bash -e`, so when `ct install` exited non-zero, the script aborted before `echo "CT_EXIT_CODE=$?"` ran and `CT_EXIT_CODE` was never set.
- The next step read `${CT_EXIT_CODE:-0}`, defaulted the missing var to `0`, and posted a success status check / PR comment despite a broken install.
- This was caught on [PR #376](https://github.com/OffchainLabs/community-helm-charts/pull/376): nitro v3.10.0 renamed `daserver` → `anytrustserver`, the DAS pod crashlooped (`exec: "/usr/local/bin/daserver": no such file or directory`), but `Test Charts (Privileged)` / `Test Charts (Status Check)` reported green.

## Fix

- Capture the exit code with `|| EXIT=$?`, which short-circuits errexit and preserves the original exit code.
- Defensively change `${CT_EXIT_CODE:-0}` → `${CT_EXIT_CODE:-1}` in the status-determination step so an unset variable is treated as failure rather than success.
- `continue-on-error: true` is preserved — downstream comment/status-check steps still need to run on failure.

## Test plan

- [ ] On a throwaway branch, point a chart's `image.repository` at a nonexistent image and confirm `Test Charts (Privileged)` and `Test Charts (Status Check)` now report failure (do not merge).
- [ ] Confirm normal passing PRs still report success.