### PR TITLE
ci(nitro): disable genesis-assertion check in Sepolia CI (NIT-4951)

### DIFF
--- a/charts/nitro/Chart.yaml
+++ b/charts/nitro/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Arbitrum Nitro
 maintainers:
   - name: OffchainLabs
 type: application
-version: 0.8.17
+version: 0.8.18
 appVersion: "v3.10.2-db30ef0"

--- a/charts/nitro/ci/sepolia-values.yaml
+++ b/charts/nitro/ci/sepolia-values.yaml
@@ -58,6 +58,12 @@ configmap:
       env-prefix: "NITROCI"
     chain:
       id: 421614
+    # Workaround for NIT-4951: chains with a pre-BoLD genesis (e.g. Arbitrum
+    # Sepolia) fail the genesis-assertion check on startup as of nitro-node
+    # v3.10.1-d7f07be, which CrashLoops the staker in CI. Disabling the check
+    # restores the prior behavior. Remove once the upstream fix lands.
+    init:
+      validate-genesis-assertion: false
     node:
       staker:
         enable: true


### PR DESCRIPTION
## What

Adds `init.validate-genesis-assertion: false` to the nitro chart's Sepolia CI values (`charts/nitro/ci/sepolia-values.yaml`), which renders into the node `config.json` as the `--init.validate-genesis-assertion=false` flag.

## Why

The **Test Charts (Privileged)** workflow installs the nitro chart against this values file (Arbitrum Sepolia from genesis, staker enabled) on every `charts/**` change — including the Renovate PRs that bump the `offchainlabs/nitro-node` image.

As of `nitro-node` `v3.10.1-d7f07be`, chains with a **pre-BoLD genesis** (e.g. Arbitrum Sepolia) fail the genesis-assertion check on startup, tracked in [NIT-4951](https://linear.app/offchain-labs/issue/NIT-4951). The pod logs `error trying to validate genesis assertion: execution reverted: ASSERTION_NOT_EXIST` and CrashLoops until helm times out:

```
Error: INSTALLATION FAILED: client rate limiter Wait returned an error: context deadline exceeded
```

This is the workaround [suggested in the thread](https://offchainlabs.slack.com/archives/C048E5TQB5L/p1779394843525529?thread_ts=1779332098.481739&cid=C048E5TQB5L) — disabling the check restores the `v3.10.0` startup behavior and unblocks the image-bump PRs.

## Reviewer notes

- **Scoped to CI only.** This touches the Sepolia CI values file, not chart defaults — downstream chart users keep the default `validate-genesis-assertion: true`.
- **Temporary.** Should be removed once the upstream fix ([nitro-private#304](https://github.com/OffchainLabs/nitro-private/pull/304)) lands and ships in a published image. A comment in the file notes this.
- Verified with `helm template` that the key renders into `config.json` and that the existing `removeKeys` behavior still strips the test sections.