### PR TITLE
fix(ci): bump GitHub Actions to Node24-compatible SHAs (SREP-2825)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,22 +17,22 @@ jobs:
     runs-on: ubuntu-4
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.14.0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.9"
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/push-chart-dev.yaml
+++ b/.github/workflows/push-chart-dev.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-4
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.inputs.branch_name }}
 

--- a/.github/workflows/push-chart.yaml
+++ b/.github/workflows/push-chart.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       paths: ${{ steps.get-modified-charts.outputs.paths }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-4
     if: ${{ needs.get-modified-charts.outputs.paths != '' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Create and push git tags
       - name: Create and push git tags

--- a/.github/workflows/readme-check-unprivileged.yaml
+++ b/.github/workflows/readme-check-unprivileged.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -125,7 +125,7 @@ jobs:
           printf '%s\n' "${CHANGES_DETAILS}" > ./pr-info/CHANGES_DETAILS
 
       - name: Upload check results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr-readme-info
           path: pr-info/
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.head_ref }}
 
@@ -162,7 +162,7 @@ jobs:
           done
 
       - name: Commit and push README updates
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: Update README for modified charts
           branch: ${{ github.head_ref }}

--- a/.github/workflows/readme-status.yaml
+++ b/.github/workflows/readme-status.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # We don't check out any code here for security
       - name: Create initial pending status check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/readme-update-privileged.yaml
+++ b/.github/workflows/readme-update-privileged.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Download check results
         if: steps.pr.outputs.found == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pr-readme-info
           path: pr-info
@@ -171,7 +171,7 @@ jobs:
 
       - name: Find existing README comment
         if: steps.results.outputs.should_comment == 'true'
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-comment
         with:
           issue-number: ${{ steps.pr.outputs.number }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Create or update PR comment
         if: steps.results.outputs.should_comment == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ steps.pr.outputs.number }}
@@ -190,7 +190,7 @@ jobs:
 
       - name: Report status check
         if: steps.pr.outputs.found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           IS_FORK: ${{ steps.pr.outputs.is_fork }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -31,13 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Generate GitHub App Token (if using GitHub App)
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
@@ -45,7 +45,7 @@ jobs:
           repositories: community-helm-charts
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v43.0.7
+        uses: renovatebot/github-action@316d7cd859606d6039a2182b7d69199e9b036835 # v46.2.1
         with:
           token: ${{ steps.generate-token.outputs.token || secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
           renovate-version: 41.59.0

--- a/.github/workflows/test-charts-status.yaml
+++ b/.github/workflows/test-charts-status.yaml
@@ -17,7 +17,7 @@ jobs:
       # We don't check out any code here for security
       - name: Check if charts were modified
         id: check-charts
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create success status (no chart changes)
         if: steps.check-charts.outputs.has_chart_changes == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history needed for ct list-changed to compare against target branch
           fetch-depth: 0
@@ -35,12 +35,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.14.0
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2
 
       - name: Identify changed charts
         id: list-changed
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.has_changes == 'true'
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.has_changes == 'true'
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Find existing comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -135,7 +135,7 @@ jobs:
           body-includes: 'Chart Installation Test'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -153,7 +153,7 @@ jobs:
           reactions: ${{ needs.test-install.outputs.status == 'success' && 'rocket' || 'eyes' }}
 
       - name: Report status check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           STATUS: ${{ needs.test-install.outputs.status || 'failure' }}


### PR DESCRIPTION
Node20 is removed from GitHub-hosted runners on 2026-09-16. All `uses:` refs bumped to Node24-compatible releases and SHA-pinned.

- `actions/checkout` v4 -> `3d3c42e5` # v7 (6 refs; 3 were already pinned to a node20 SHA)
- `actions/github-script` v7 -> `3a2844b7` # v9 (5 refs; 2 were already pinned to a node20 SHA)
- `azure/setup-helm` v3 -> `9bc31f4e` # v5 (2 refs)
- `actions/setup-python` v4 -> `5fda3b95` # v7
- `actions/upload-artifact` v4 -> `043fb46d` # v7
- `actions/download-artifact` v4 -> `3e5f45b2` # v8
- `stefanzweifel/git-auto-commit-action` v5 -> `4a55954c` # v7 (2 refs)
- `peter-evans/find-comment` v3 -> `b30e6a3c` # v4 (2 refs)
- `peter-evans/create-or-update-comment` v4 -> `e8674b07` # v5 (2 refs)
- `actions/create-github-app-token` v2 -> `bcd2ba49` # v3
- `renovatebot/github-action` v43.0.7 -> `316d7cd8` # v46.2.1
- `helm/kind-action` v1.9.0 -> `ef37e7f3` # v1
- `helm/chart-testing-action` v2.6.0/v2.6.1 -> `6ec842c0` # v2 (composite, pinned for consistency)

Not changed: `a-thomas-22/helm-push-action` is a Docker action (`runs.using: docker`), unaffected by the Node20 removal.

Every replacement SHA was verified against its `action.yml` `runs.using` (`node24`) and confirmed to match the tagged release.

Ref: https://linear.app/offchain-labs/issue/SREP-2825