### PR TITLE
fix(ci): make chart tagging robust to path and version parsing

### DIFF
--- a/.github/workflows/push-chart.yaml
+++ b/.github/workflows/push-chart.yaml
@@ -29,8 +29,25 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.event.after }}
         run: |
-          paths=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep ^charts/ | cut -d/ -f1,2 | uniq | tr '\n' ' ')
-          echo "paths=${paths}" >> $GITHUB_OUTPUT
+          set -f
+          charts=()
+          while IFS= read -r -d '' file; do
+            [[ "$file" == charts/*/* ]] || continue
+            IFS=/ read -r _ name _ <<< "$file"
+            if [[ ! "$name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+              echo "::error::Refusing to process chart directory with unexpected characters: ${file}"
+              exit 1
+            fi
+            charts+=("charts/${name}")
+          done < <(git diff --name-only -z "$BEFORE_SHA" "$AFTER_SHA")
+
+          paths=""
+          if [[ ${#charts[@]} -gt 0 ]]; then
+            paths=$(printf '%s\n' "${charts[@]}" | sort -u | tr '\n' ' ' | sed 's/ *$//')
+          fi
+
+          echo "Modified charts: ${paths}"
+          echo "paths=${paths}" >> "$GITHUB_OUTPUT"
 
   push-charts:
     needs: get-modified-charts
@@ -44,28 +61,29 @@ jobs:
         env:
           MODIFIED_PATHS: ${{ needs.get-modified-charts.outputs.paths }}
         run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
           IFS=' ' read -ra ADDR <<< "$MODIFIED_PATHS"
           for path in "${ADDR[@]}"; do
-            # Extract the chart name from the path
-            chart_name=$(basename $path)
-            
-            # Only capture the first occurrence of 'version:' to ignore dependencies
-            version=$(grep -m1 'version:' $path/Chart.yaml | awk '{print $2}')
-            
-            # Create the tag name by prepending the chart name and adding '-dev'
+            chart_name=$(basename "$path")
+
+            # Anchored so an indented dependency version can never win
+            version=$(grep -m1 '^version:' "${path}/Chart.yaml" | awk '{print $2}')
+            if [[ -z "$version" ]]; then
+              echo "::error::Could not determine chart version from ${path}/Chart.yaml"
+              exit 1
+            fi
+
             tag="${chart_name}-${version}"
 
-            # Configure git
-            git config user.name "GitHub Actions"
-            git config user.email "actions@github.com"
-            
             # Delete existing tag if exists
-            git tag -d $tag || true
-            git push origin :refs/tags/$tag || true
-            
+            git tag -d "$tag" || true
+            git push origin ":refs/tags/$tag" || true
+
             # Create and push new tag
-            git tag $tag
-            git push origin $tag
+            git tag "$tag"
+            git push origin "$tag"
           done
 
       - uses: a-thomas-22/helm-push-action@780d6973e12f5dd24dcd6f4a2975f14d87c62699 # v0.0.29


### PR DESCRIPTION
Hygiene pass over the tag/publish job on `main`.

- Chart directories are derived from NUL-separated diff output, and names outside a safe character set are rejected
- Files sitting directly under `charts/` are skipped; previously they produced a bogus chart path that would fail later in the job
- The version grep is anchored to `^version:`
- The job now fails explicitly when no version can be determined
- `$path` and `$tag` expansions are quoted

The version anchoring fixes a latent bug rather than a theoretical one. With a `dependencies:` block above `version:` in a `Chart.yaml`, the current unanchored grep returns the *dependency's* version, so the chart would be tagged and pushed under the wrong number. No chart has a dependencies block today, so nothing is currently mispublished.

Verified with `actionlint` and by running both extracted steps against a scratch repo with a stubbed `git`.

One thing I did **not** change, since it is a release-policy call: the job still deletes and recreates an existing tag, and ChartMuseum is still pushed with `FORCE: "True"`, so a published chart version can be silently replaced. Happy to follow up if you want that to fail instead.

Ref: SREP-