### PR TITLE
fix(ci): split chart test execution from result reporting

### DIFF
--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -7,11 +7,7 @@ on:
     paths:
       - "charts/**"
 
-# Limit permissions to only what's needed
-permissions:
-  contents: read
-  pull-requests: write  # Needed to comment on results
-  checks: write  # Needed to create status checks
+permissions: {}
 
 concurrency:
   group: test-install-${{ github.event.pull_request.number }}
@@ -21,6 +17,13 @@ jobs:
   test-install:
     runs-on: ubuntu-8
     environment: chart-testing
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.test-status.outputs.status }}
+      status_text: ${{ steps.test-status.outputs.status_text }}
+      has_changes: ${{ steps.list-changed.outputs.has_changes }}
+      changed_charts: ${{ steps.list-changed.outputs.changed_charts }}
 
     steps:
       - name: Checkout PR code
@@ -29,7 +32,6 @@ jobs:
           # Full history needed for ct list-changed to compare against target branch
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-          # Important: Don't persist credentials when checking out PR code
           persist-credentials: false
 
       - name: Set up Helm
@@ -47,22 +49,25 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch "$DEFAULT_BRANCH" --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "Changed charts: $changed"
             formatted=$(echo "$changed" | tr '\n' ' ' | xargs)
-            echo "CHANGED_CHARTS=$formatted" >> $GITHUB_ENV
-            echo "HAS_CHANGES=true" >> $GITHUB_ENV
+            echo "Changed charts: $formatted"
+            echo "changed_charts=$formatted" >> "$GITHUB_OUTPUT"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "No chart changes detected by chart-testing."
-            echo "HAS_CHANGES=false" >> $GITHUB_ENV
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create kind cluster
-        if: env.HAS_CHANGES == 'true'
+        if: steps.list-changed.outputs.has_changes == 'true'
         uses: helm/kind-action@v1.9.0
 
-      - name: Prepare CI secrets for Helm
-        if: env.HAS_CHANGES == 'true'
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.has_changes == 'true'
+        id: chart-test
+        continue-on-error: true
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           CI_TEST_ACCOUNT_PRIVATE_KEY: ${{ secrets.CI_TEST_ACCOUNT_PRIVATE_KEY }}
           CI_PARENT_CHAIN_URL_SEPOLIA: ${{ secrets.CI_PARENT_CHAIN_URL_SEPOLIA }}
           CI_BASELINE_RPC_KEY_SEPOLIA: ${{ secrets.CI_BASELINE_RPC_KEY_SEPOLIA }}
@@ -74,11 +79,8 @@ jobs:
           IFS=$'\n' read -r -d '' -a secret_names < <(env | grep '^CI_' | sed 's/=.*//' && printf '\0')
 
           for secret_name in "${secret_names[@]}"; do
-            # Extract the variable name without the CI_ prefix for Helm values
-            variable_name=$(echo $secret_name | sed 's/^CI_//')
-            # Get the value of the dynamic variable name
+            variable_name=${secret_name#CI_}
             secret_value=${!secret_name}
-            # Append to the secrets string in the required format
             if [ -z "$secrets_for_helm" ]; then
               secrets_for_helm="ci.secrets.${variable_name}=${secret_value}"
             else
@@ -86,38 +88,44 @@ jobs:
             fi
           done
 
-          # Remove the initial comma to clean up the format
-          secrets_for_helm=${secrets_for_helm#,}
+          extra_args=()
+          if [[ -n "$secrets_for_helm" ]]; then
+            extra_args=(--helm-extra-set-args "--set ${secrets_for_helm}")
+          fi
 
-          # Format the entire string for --helm-extra-set-args, ensuring it's properly quoted
-          helm_extra_set_args="--set ${secrets_for_helm}"
-
-          # Use the command directly or set the HELM_EXTRA_SET_ARGS environment variable for later use in the workflow
-          echo "HELM_EXTRA_SET_ARGS=${helm_extra_set_args}" >> $GITHUB_ENV
-
-      - name: Run chart-testing (install)
-        if: env.HAS_CHANGES == 'true'
-        id: chart-test
-        continue-on-error: true
-        run: |
           EXIT=0
-          ct install --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml --helm-extra-set-args "$HELM_EXTRA_SET_ARGS" || EXIT=$?
-          echo "CT_EXIT_CODE=$EXIT" >> $GITHUB_ENV
+          ct install --target-branch "$DEFAULT_BRANCH" --config ct.yaml "${extra_args[@]}" || EXIT=$?
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
 
       - name: Determine test status
         id: test-status
+        env:
+          HAS_CHANGES: ${{ steps.list-changed.outputs.has_changes }}
+          CT_EXIT_CODE: ${{ steps.chart-test.outputs.exit_code }}
         run: |
           if [[ "$HAS_CHANGES" == "false" ]]; then
-            echo "STATUS=success" >> $GITHUB_ENV
-            echo "STATUS_TEXT=No chart changes detected" >> $GITHUB_ENV
+            status=success
+            status_text="No chart changes detected"
           elif [[ "${CT_EXIT_CODE:-1}" == "0" ]]; then
-            echo "STATUS=success" >> $GITHUB_ENV
-            echo "STATUS_TEXT=succeeded" >> $GITHUB_ENV
+            status=success
+            status_text=succeeded
           else
-            echo "STATUS=failure" >> $GITHUB_ENV
-            echo "STATUS_TEXT=failed" >> $GITHUB_ENV
+            status=failure
+            status_text=failed
           fi
 
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          echo "status_text=${status_text}" >> "$GITHUB_OUTPUT"
+
+  report:
+    needs: test-install
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: write
+
+    steps:
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
         id: find-comment
@@ -132,47 +140,44 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           body: |
-            ## Chart Installation Test ${{ env.STATUS_TEXT }} ${{ env.STATUS == 'success' && '✅' || '❌' }}
+            ## Chart Installation Test ${{ needs.test-install.outputs.status_text || 'failed' }} ${{ needs.test-install.outputs.status == 'success' && '✅' || '❌' }}
 
-            The chart installation test for commit `${{ github.event.pull_request.head.sha }}` has ${{ env.STATUS_TEXT }}.
+            The chart installation test for commit `${{ github.event.pull_request.head.sha }}` has ${{ needs.test-install.outputs.status_text || 'failed' }}.
 
-            ${{ env.HAS_CHANGES == 'true' && format('Changed charts: `{0}`', env.CHANGED_CHARTS) || '' }}
+            ${{ needs.test-install.outputs.has_changes == 'true' && format('Changed charts: `{0}`', needs.test-install.outputs.changed_charts) || '' }}
 
             [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-            ${{ env.STATUS != 'success' && '⚠️ Please check the workflow logs for details on the failure.' || '' }}
+            ${{ needs.test-install.outputs.status != 'success' && '⚠️ Please check the workflow logs for details on the failure.' || '' }}
           edit-mode: replace
-          reactions: ${{ env.STATUS == 'success' && 'rocket' || 'eyes' }}
+          reactions: ${{ needs.test-install.outputs.status == 'success' && 'rocket' || 'eyes' }}
 
       - name: Report status check
         uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STATUS: ${{ needs.test-install.outputs.status || 'failure' }}
+          STATUS_TEXT: ${{ needs.test-install.outputs.status_text || 'failed' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            try {
-              const { owner, repo } = context.repo;
-              const commit_sha = '${{ github.event.pull_request.head.sha }}';
-              const status = process.env.STATUS;
-              const status_text = process.env.STATUS_TEXT;
+            const { owner, repo } = context.repo;
+            const head_sha = process.env.HEAD_SHA;
+            const status = process.env.STATUS;
+            const status_text = process.env.STATUS_TEXT;
 
-              const workflow_run_url = `https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}`;
+            await github.rest.checks.create({
+              owner,
+              repo,
+              name: 'Chart Installation Test',
+              head_sha,
+              status: 'completed',
+              conclusion: status === 'success' ? 'success' : 'failure',
+              output: {
+                title: `Chart Installation ${status_text}`,
+                summary: `The chart installation test has ${status_text}.`,
+              },
+              details_url: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+            });
 
-              // Report status check
-              await github.rest.checks.create({
-                owner,
-                repo,
-                name: 'Chart Installation Test',
-                head_sha: commit_sha,
-                status: 'completed',
-                conclusion: status === 'success' ? 'success' : 'failure',
-                output: {
-                  title: `Chart Installation ${status_text}`,
-                  summary: `The chart installation test has ${status_text}.`
-                },
-                details_url: workflow_run_url
-              });
-              console.log(`Created status check for commit ${commit_sha}`);
-            } catch (error) {
-              console.error(`Error creating status check: ${error.message}`);
-              core.setFailed(`Failed to create status check: ${error.message}`);
-            }
+            core.info(`Created status check for commit ${head_sha}`);


### PR DESCRIPTION
The job that checks out and installs the PR's charts also carried `pull-requests: write` and `checks: write`. Reporting now happens in a separate job that checks out nothing.

- `test-install` keeps `contents: read` only; workflow-level permissions are now empty
- `report` carries `pull-requests: write` and `checks: write`, and runs on `!cancelled()` so a failed run still posts a result
- State moves between steps and jobs as outputs rather than `GITHUB_ENV`, so the assembled `--set` string is no longer written into the job environment
- `--helm-extra-set-args` is omitted entirely when no `CI_` secrets are configured; previously that case passed a bare `--set`

The `chart-testing` environment gate, the secret names, and the `--set` values are unchanged, so the `Chart Installation Test` check behaves the same.

Verified with `actionlint` and by running the extracted steps with a stubbed `ct`: the `--helm-extra-set-args` string is identical to before, and all four status permutations resolve as they did previously.

Ref: SREP-