### PR TITLE
fix(ci): correct Renovate bot username to stop duplicate dashboards

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -74,9 +74,11 @@ jobs:
           # Additional useful settings
           RENOVATE_DEPENDENCY_DASHBOARD: false
 
-          # Renovate app settings (when using GitHub App)
-          RENOVATE_USERNAME: ${{ github.repository_owner }}-renovate[bot]
-          RENOVATE_GIT_AUTHOR: ${{ github.repository_owner }}-renovate[bot] <${{ github.repository_owner }}-renovate[bot]@users.noreply.github.com>
+          # Must match the GitHub App's actual bot login: Renovate filters the
+          # issue/PR list by this username to find its own dashboard, and a
+          # mismatch makes it open a duplicate dashboard on every run.
+          RENOVATE_USERNAME: ocl-renovate[bot]
+          RENOVATE_GIT_AUTHOR: ocl-renovate[bot] <ocl-renovate[bot]@users.noreply.github.com>
 
       - name: Renovate Summary
         if: always()

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -74,9 +74,6 @@ jobs:
           # Additional useful settings
           RENOVATE_DEPENDENCY_DASHBOARD: false
 
-          # Must match the GitHub App's actual bot login: Renovate filters the
-          # issue/PR list by this username to find its own dashboard, and a
-          # mismatch makes it open a duplicate dashboard on every run.
           RENOVATE_USERNAME: ocl-renovate[bot]
           RENOVATE_GIT_AUTHOR: ocl-renovate[bot] <ocl-renovate[bot]@users.noreply.github.com>
 


### PR DESCRIPTION
## Problem

Every open issue in this repo was a duplicate Dependency Dashboard — 155 of them (#377–#545), one per scheduled Renovate run since June.

`RENOVATE_USERNAME` was built from `${{ github.repository_owner }}`, expanding to `OffchainLabs-renovate[bot]`. The GitHub App token actually authenticates as `ocl-renovate[bot]`, the author of every one of those issues.

Renovate filters the repo's issue list by its configured username to locate its own dashboard. With a username matching nothing, that lookup returned empty on every run, so Renovate concluded no dashboard existed and opened a fresh one. The same lookup backs the close path, which is why `dependencyDashboardAutoclose` and `dependencyDashboard: false` never cleaned up the strays either.

## Change

Hardcode the app's real bot login for both `RENOVATE_USERNAME` and `RENOVATE_GIT_AUTHOR`. Dropping the overrides entirely would be tidier, but GitHub App installation tokens can't be resolved through `/user`, so autodetection isn't dependable here.

## Cleanup

The 154 duplicates have been closed out of band, leaving #545 open for Renovate to reconcile.

## Follow-up

`dependencyDashboard: false` is set in both `.github/renovate-config.json` and the workflow env, yet dashboards were still being created — the current one carries an "Edited/Blocked" entry for `renovate/nitro-node`, which is the likely trigger for Renovate forcing a dashboard regardless. This PR stops the duplication; whether it stops creation needs a `workflow_dispatch` run at `debug` after merge to confirm.

Ref: SREP-3630
