### PR TITLE
fix(ci): stop Renovate entrypoint failing on Debian-owned PyYAML

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -21,7 +21,7 @@ chmod +x /usr/local/bin/yq
 echo "Installing Python and dependencies..."
 apt-get update -qq
 apt-get install -y -qq python3 python3-pip > /dev/null 2>&1
-pip3 install -q --break-system-packages "pyyaml==${PYYAML_VERSION}"
+pip3 install -q --break-system-packages --ignore-installed "pyyaml==${PYYAML_VERSION}"
 
 # Install Helm for chart rendering
 echo "Installing Helm ${HELM_VERSION}..."


### PR DESCRIPTION
## Problem

Every Renovate run has failed since 2026-08-14 — dependency updates have been silently stalled for a week. The job dies before Renovate starts:

```
Installing Python and dependencies...
ERROR: Cannot uninstall PyYAML 6.0.1, RECORD file not found. Hint: The package was installed by debian.
```

`ghcr.io/renovatebot/renovate` already carries Debian-packaged PyYAML 6.0.1, which pip cannot uninstall to make way for the pinned 6.0.3 because the distro package ships no `RECORD` file. With `set -e` at the top of the entrypoint, the script aborts there and never reaches `exec renovate`.

This came in with #550: the run immediately before it merged succeeded, and every run since has failed.

## Change

Add `--ignore-installed` so pip lays down the pinned version without trying to remove the distro copy. Keeps #550's pinning intent intact.

## Checked while here

- helm `v3.13.0`'s pinned SHA256 matches the published `get.helm.sh` checksum
- PyYAML `6.0.3` does exist on PyPI

So the pins themselves are fine — only the uninstall path was broken.

## Follow-up

Renovate has not run since before #554 merged, so that fix (duplicate dependency dashboards) is still unverified in practice. Once this lands I'll dispatch the workflow at `debug` and confirm no new dashboard appears, and whether `dependencyDashboard: false` is honoured at all given the "Edited/Blocked" entry on #545.

Ref: SREP-3631
